### PR TITLE
Removed kapt to work with Airbnb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.60'
+    ext.kotlinVersion = '1.2.41'
     ext.supportLibVersion = '27.1.1'
     ext.lifecycleVersion = '1.1.1'
     ext.robolectricVersion = '3.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.0.1
-VERSION_CODE=1
+VERSION_NAME=0.0.3
+VERSION_CODE=3
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=MvRx is an Android application framework that makes product development fast and fun.

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply from: 'gradle-maven-push.gradle'
 
-version '0.0.1'
-
 sourceCompatibility = 1.8
 
 android {
@@ -14,8 +12,6 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 1
-        versionName "0.0.1"
     }
     lintOptions {
         abortOnError true
@@ -37,12 +33,12 @@ androidExtensions {
 }
 
 dependencies {
+    api "android.arch.lifecycle:extensions:$lifecycleVersion"
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
-    implementation "android.arch.lifecycle:extensions:$lifecycleVersion"
-    kapt "android.arch.lifecycle:compiler:$lifecycleVersion"
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation "io.reactivex.rxjava2:rxjava:2.2.0"
 


### PR DESCRIPTION
I was getting this in the airbnb app with the kapt lifecycle compiler. However, LifecycleAwareObservable seems to work without it.
Is this safe to do @BenSchwab @elihart 
```
Error: Program type already present: kotlinx.android.extensions.CacheImplementation$Companion
com.android.tools.r8.CompilationFailedException: Compilation failed to complete
	at com.android.tools.r8.utils.ExceptionUtils.withCompilationHandler(ExceptionUtils.java:71)
	at com.android.tools.r8.utils.ExceptionUtils.withD8CompilationHandler(ExceptionUtils.java:41)
	at com.android.tools.r8.D8.run(D8.java:67)
```