### PR TITLE
Remove readyToInvalidate

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
@@ -35,7 +35,7 @@ inline fun <T, VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.fragmentViewM
 ) where T : Fragment,
         T : MvRxView = lazy {
     MvRxViewModelProvider.get(viewModelClass, this, keyFactory(), stateFactory)
-        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { if (readyToInvalidate()) invalidate() }) }
+        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { invalidate() }) }
 }
 
 /**
@@ -50,7 +50,7 @@ fun <T, VM : BaseMvRxViewModel<S>, S : MvRxState> T.existingViewModel(
         T : MvRxView = lazy {
     val factory = MvRxFactory { throw IllegalStateException("ViewModel for ${requireActivity()}[${keyFactory()}] does not exist yet!") }
     ViewModelProviders.of(requireActivity(), factory).get(keyFactory(), viewModelClass.java)
-        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { if (readyToInvalidate()) invalidate() }) }
+        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { invalidate() }) }
 }
 
 /**
@@ -69,7 +69,7 @@ inline fun <T, VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.activityViewM
         T : MvRxView = lazy {
     if (requireActivity() !is MvRxViewModelStoreOwner) throw IllegalArgumentException("Your Activity must be a MvRxViewModelStoreOwner!")
     MvRxViewModelProvider.get(viewModelClass, requireActivity(), keyFactory(), stateFactory)
-        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { if (readyToInvalidate()) invalidate() }) }
+        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { invalidate() }) }
 }
 
 /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -12,11 +12,6 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * Override this to handle any state changes from MvRxViewModels created through MvRx Fragment delegates.
      */
     fun invalidate()
-    /**
-     * Override this to prevent any invalidate calls before certain conditions.
-     */
-    fun readyToInvalidate(): Boolean
-
 
     /**
      * Subscribes to all state updates for the given viewModel.
@@ -27,7 +22,7 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
             shouldUpdate: ((S, S) -> Boolean)? = null,
             observerScheduler: Scheduler = AndroidSchedulers.mainThread(),
             subscriber: ((S) -> Unit)? = null
-    ) = subscribe(this@MvRxView, shouldUpdate, observerScheduler, subscriber ?: { if (readyToInvalidate()) invalidate() })
+    ) = subscribe(this@MvRxView, shouldUpdate, observerScheduler, subscriber ?: { invalidate() })
 
     /**
      * Subscribes to all state updates for the given viewModel. The subscriber will receive the previous state and the new state.

--- a/sample/src/main/java/com/airbnb/mvrx/sample/core/BaseFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/core/BaseFragment.kt
@@ -12,8 +12,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyRecyclerView
-import com.airbnb.mvrx.MvRx
 import com.airbnb.mvrx.BaseMvRxFragment
+import com.airbnb.mvrx.MvRx
 import com.airbnb.mvrx.sample.R
 
 abstract class BaseFragment : BaseMvRxFragment() {
@@ -35,8 +35,6 @@ abstract class BaseFragment : BaseMvRxFragment() {
             toolbar.setupWithNavController(findNavController())
         }
     }
-
-    override fun readyToInvalidate() = isAdded && view != null
 
     override fun invalidate() {
         recyclerView.requestModelBuild()


### PR DESCRIPTION
I don't think this API should live in MvRx.

For starters, it doesn't work well. It doesn't trigger an invalidate when it becomes true.

I'll keep this behavior in MvRxFragment in the Airbnb app but we should consider removing that as well.

@elihart @BenSchwab 