### PR TITLE
Removed stateFactory and renamed args

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
@@ -187,10 +187,10 @@ fun <V : Any> args() = object : ReadOnlyProperty<Fragment, V> {
     override fun getValue(thisRef: Fragment, property: KProperty<*>): V {
         if (value == null) {
             val args = thisRef.arguments ?: throw IllegalArgumentException("There are no fragment arguments!")
-            if (!args.containsKey(MvRx.KEY_ARG)) throw IllegalArgumentException("MvRx arguments not found at key MvRx.KEY_ARG!")
             val argUntyped = args.get(MvRx.KEY_ARG)
+            argUntyped ?: throw IllegalArgumentException("MvRx arguments not found at key MvRx.KEY_ARG!")
             @Suppress("UNCHECKED_CAST")
-            value = argUntyped as? V ?: throw IllegalArgumentException("MvRx arguments are the wrong type! It is ${argUntyped::class.simpleName}.")
+            value = argUntyped as V
         }
         return value ?: throw IllegalArgumentException("")
     }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/MvRxFragmentTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/MvRxFragmentTest.kt
@@ -8,6 +8,10 @@ import org.junit.Test
 @Parcelize
 data class MvrxArgsTestArgs(val count: Int = 0) : Parcelable
 
+
+@Parcelize
+data class MvrxArgsTestArgs2(val count: Int = 0) : Parcelable
+
 class MvRxArgsFragment : BaseMvRxFragment() {
     val args: MvrxArgsTestArgs by args()
 
@@ -25,5 +29,17 @@ class MvRxFragmentTest : MvRxBaseTest() {
     fun testSetArgs() {
         val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>(args = MvrxArgsTestArgs(2))
         Assert.assertEquals(2, fragment.args.count)
+    }
+
+    @Test(expected = ClassCastException::class)
+    fun testSetWrongArgs() {
+        val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>(args = MvrxArgsTestArgs2(2))
+        fragment.args
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testNoArgs() {
+        val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>()
+        fragment.args
     }
 }


### PR DESCRIPTION
* Now that we have the Fragment arguments -> initial state paradigm, the state factory must be removed for consistency.
* Renamed the arg delegate to args because that is more accurate.

@BenSchwab @elihart 