### PR TITLE
Always deliver state changes when unlocked

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateStore.kt
@@ -107,6 +107,7 @@ open class MvRxStateStore<S : Any>(initialState: S) : Disposable {
         if (lifecycleOwner == null) return observable.subscribe(subscriber)
 
         val lifecycleAwareObserver = MvRxLifecycleAwareObserver.Builder<S>(lifecycleOwner)
+            .alwaysDeliverValueWhenUnlocked()
             .onNext(subscriber)
             .build()
         return observable.subscribeWith(lifecycleAwareObserver)
@@ -129,6 +130,7 @@ open class MvRxStateStore<S : Any>(initialState: S) : Disposable {
         if (lifecycleOwner == null) return observable.subscribe { pair -> subscriber(pair.first, pair.second) }
 
         val lifecycleAwareObserver = MvRxLifecycleAwareObserver.Builder<Pair<S, S>>(lifecycleOwner)
+            .alwaysDeliverValueWhenUnlocked()
             .onNext { pair -> subscriber(pair.first, pair.second) }
             .build()
         return observable.subscribeWith(lifecycleAwareObserver)

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/StateStoreTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/StateStoreTest.kt
@@ -199,6 +199,40 @@ class StateStoreTest : BaseTest() {
     }
 
     @Test
+    fun testSubscribeCalledOnRestart() {
+        lifecycleOwner.lifecycle.markState(Lifecycle.State.RESUMED)
+
+        var callCount = 0
+        store.subscribe(lifecycleOwner) {
+            callCount++
+        }
+        assertEquals(1, callCount)
+        lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertEquals(1, callCount)
+        lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertEquals(1, callCount)
+        lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        assertEquals(2, callCount)
+    }
+
+    @Test
+    fun testSubscribeWithHistoryCalledOnRestart() {
+        lifecycleOwner.lifecycle.markState(Lifecycle.State.RESUMED)
+
+        var callCount = 0
+        store.subscribeWithHistory(lifecycleOwner) { _, _ ->
+            callCount++
+        }
+        assertEquals(1, callCount)
+        lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertEquals(1, callCount)
+        lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertEquals(1, callCount)
+        lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        assertEquals(2, callCount)
+    }
+
+    @Test
     fun testAddToList() {
         var callCount = 0
         store.subscribe {


### PR DESCRIPTION
Without this, if you return to a Fragment with an activityViewModel and there were no state changes, invalidate() wouldn't be called. These tests fail without `alwaysDeliverValueWhenUnlocked()`.

Fixes #15 
@elihart @BenSchwab 