### PR TITLE
removed volatile for state

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateStore.kt
@@ -22,7 +22,7 @@ import java.util.LinkedList
  * until the subscriber callback completes. This will prevent the state from updating in the middle
  * of the subscription callback.
  */
-open class MvRxStateStore<S : Any>(val initialState: S) : Disposable {
+open class MvRxStateStore<S : Any>(private val initialState: S) : Disposable {
     /**
      * The subject is where state changes should be pushed to.
      */
@@ -48,7 +48,8 @@ open class MvRxStateStore<S : Any>(val initialState: S) : Disposable {
      * current state.
      */
     val state: S
-        get() = subject.value ?: initialState
+        // value must be present here, since the subject is created with initialState
+        get() = subject.value!!
 
     init {
 


### PR DESCRIPTION
1. removed `subject.toSerialized()` since we only emit value on merge queue, or set value during initialization before any merges. 
2. used `subject.value` to get the current state, which is thread safe. 
3. Do not use `@Volatile` since it does not provide atomicity. It only guarantees visibility by not caching it: http://jeremymanson.blogspot.com/2007/08/atomicity-visibility-and-ordering.html
 
Note that this only solves threading issue, however, it think it's better not to expose the `state` at all, which requires much larger change in `StateContainer.kt`

@gpeal @BenSchwab @elihart 
