### PR TITLE
move pure function validation in merge queue

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -5,7 +5,6 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.ViewModel
 import android.os.Looper
 import android.support.annotation.CallSuper
-import android.support.annotation.VisibleForTesting
 import android.util.Log
 import io.reactivex.Observable
 import io.reactivex.Scheduler
@@ -27,8 +26,7 @@ abstract class BaseMvRxViewModel<S : MvRxState> : ViewModel() {
     /**
      * This has to be lazy so that initialState can be initialized in the child.
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    val stateStore: MvRxStateStore<S> by lazy { MvRxStateStore(initialState) }
+    private val stateStore: MvRxStateStore<S> by lazy { MvRxStateStore(initialState) }
 
     /**
      * Enable debug features which check for certain properties like idempotent reducers and immutable state.

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/IdempotentReducerTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/IdempotentReducerTest.kt
@@ -6,9 +6,8 @@ import java.util.concurrent.Semaphore
 data class IdempotentReducerState(val count: Int = 0) : MvRxState
 class IdempotentReducerTest : BaseTest() {
 
-    @Test
+    @Test(expected = IllegalArgumentException::class)
     fun impureReducerShouldFail() {
-        val semaphore = Semaphore(0)
         class ImpureViewModel(override val initialState: IdempotentReducerState) : TestMvRxViewModel<IdempotentReducerState>() {
             private var count = 0
             fun impureReducer() {
@@ -18,16 +17,11 @@ class IdempotentReducerTest : BaseTest() {
                 }
             }
         }
-        val impureViewModel = ImpureViewModel(IdempotentReducerState())
-        impureViewModel.stateStore.semaphoreForTesting = semaphore
-        impureViewModel.impureReducer()
-        semaphore.acquire()
-        assert(impureViewModel.stateStore.throwableForTesting is IllegalArgumentException)
+        ImpureViewModel(IdempotentReducerState()).impureReducer()
     }
 
     @Test
     fun pureReducerShouldNotFail() {
-        val semaphore = Semaphore(0)
         class PureViewModel(override val initialState: IdempotentReducerState) : TestMvRxViewModel<IdempotentReducerState>() {
             fun pureReducer() {
                 setState {
@@ -36,11 +30,6 @@ class IdempotentReducerTest : BaseTest() {
                 }
             }
         }
-
-        val pureViewModel = PureViewModel(IdempotentReducerState())
-        pureViewModel.stateStore.semaphoreForTesting = semaphore
-        pureViewModel.pureReducer()
-        semaphore.acquire()
-        assert(pureViewModel.stateStore.throwableForTesting == null)
+        PureViewModel(IdempotentReducerState()).pureReducer()
     }
 }


### PR DESCRIPTION
Moved pure function validation to merge queue, because

1. `setState` can be called in any thread, including main thread, and diffing (twice) is an expensive operation (despite that it's debug mode only)
2. there's a race condition if we directly access the state: there could be pending reducers in the merge thread


Note that we have to enqueue `setState` block instead of `getState`, otherwise the state wouldn't be the same as the state to be validated (it would be the state after being reduced), since setState has higher priority than getState. 

@gpeal @BenSchwab @elihart 