### PR TITLE
Idempotent vs pure functions

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -29,7 +29,7 @@ abstract class BaseMvRxViewModel<S : MvRxState> : ViewModel() {
     private val stateStore: MvRxStateStore<S> by lazy { MvRxStateStore(initialState) }
 
     /**
-     * Enable debug features which check for certain properties like idempotent reducers and immutable state.
+     * Enable debug features which check for certain properties like pure reducers and immutable state.
      */
     protected abstract val debugMode: Boolean
 

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
@@ -1,14 +1,13 @@
 package com.airbnb.mvrx
 
 import org.junit.Test
-import java.util.concurrent.Semaphore
 
-data class IdempotentReducerState(val count: Int = 0) : MvRxState
-class IdempotentReducerTest : BaseTest() {
+data class PureReducerValidationState(val count: Int = 0) : MvRxState
+class PureReducerValidationTest : BaseTest() {
 
     @Test(expected = IllegalArgumentException::class)
     fun impureReducerShouldFail() {
-        class ImpureViewModel(override val initialState: IdempotentReducerState) : TestMvRxViewModel<IdempotentReducerState>() {
+        class ImpureViewModel(override val initialState: PureReducerValidationState) : TestMvRxViewModel<PureReducerValidationState>() {
             private var count = 0
             fun impureReducer() {
                 setState {
@@ -17,12 +16,12 @@ class IdempotentReducerTest : BaseTest() {
                 }
             }
         }
-        ImpureViewModel(IdempotentReducerState()).impureReducer()
+        ImpureViewModel(PureReducerValidationState()).impureReducer()
     }
 
     @Test
     fun pureReducerShouldNotFail() {
-        class PureViewModel(override val initialState: IdempotentReducerState) : TestMvRxViewModel<IdempotentReducerState>() {
+        class PureViewModel(override val initialState: PureReducerValidationState) : TestMvRxViewModel<PureReducerValidationState>() {
             fun pureReducer() {
                 setState {
                     val state = copy(count = count + 1)
@@ -30,6 +29,6 @@ class IdempotentReducerTest : BaseTest() {
                 }
             }
         }
-        PureViewModel(IdempotentReducerState()).pureReducer()
+        PureViewModel(PureReducerValidationState()).pureReducer()
     }
 }


### PR DESCRIPTION
Idempotent and pure functions are different concepts: 

Idempotent means `f(f(x)) == f(x)`
Pure means `f(x) == f(x)`

For example, `reduce { copy(count = count + 1) }` is pure, since the result is deterministic. It's not idempotent since running it twice would be different from running it once. 
Another example, `reduce { copy(count = 1) }` is both pure and idempotent. 

Both examples are valid/pure reducers. 

@gpeal @BenSchwab @elihart 