### PR TITLE
Add @RestrictTo to subscribe functions that take a LifecycleOwner

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.ViewModel
 import android.support.annotation.CallSuper
+import android.support.annotation.RestrictTo
 import android.util.Log
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -79,8 +80,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      * Validates a number of properties on the state class. This cannot be called from the main thread because it does
      * a fair amount of reflection.
      */
-    @SuppressLint("VisibleForTests")
-    internal fun validateState(initialState: S) {
+    private fun validateState(initialState: S) {
         if (state::class.visibility != KVisibility.PUBLIC) {
             throw IllegalStateException("Your state class ${state::class.qualifiedName} must be public.")
         }
@@ -158,23 +158,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     }
 
     /**
-     * Subscribe to state updates.
-     *
-     * This is only open so it can be mocked for testing. Do not extend it.
-     *
-     * @param owner The LifecycleOwner such as a Fragment or Activity that wants to subscribe to
-     *                     state updates.
-     * @param shouldUpdate A lambda that takes the previous and new state and returns whether the
-     *                     subscriber should be notified.
-     * @param subscriber A lambda that will get called every time the state changes.
-     */
-    internal fun subscribe(
-        owner: LifecycleOwner,
-        shouldUpdate: ((S, S) -> Boolean)? = null,
-        subscriber: (S) -> Unit
-    ) = subscribeLifecycle(owner, shouldUpdate, subscriber)
-
-    /**
      * For ViewModels that want to subscribe to itself.
      */
     protected fun subscribe(
@@ -182,14 +165,12 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         subscriber: (S) -> Unit
     ) = subscribeLifecycle(null, shouldUpdate, subscriber)
 
-    /**
-     * Subscribe to state changes for only a single property.
-     */
-    internal fun <A> selectSubscribe(
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun subscribe(
         owner: LifecycleOwner,
-        prop1: KProperty1<S, A>,
-        subscriber: (A) -> Unit
-    ) = selectSubscribeInternal(owner, prop1, subscriber)
+        shouldUpdate: ((S, S) -> Boolean)? = null,
+        subscriber: (S) -> Unit
+    ) = subscribeLifecycle(owner, shouldUpdate, subscriber)
 
     /**
      * Subscribe to state changes for only a single property.
@@ -198,6 +179,13 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop1: KProperty1<S, A>,
         subscriber: (A) -> Unit
     ) = selectSubscribeInternal(null, prop1, subscriber)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun <A> selectSubscribe(
+        owner: LifecycleOwner,
+        prop1: KProperty1<S, A>,
+        subscriber: (A) -> Unit
+    ) = selectSubscribeInternal(owner, prop1, subscriber)
 
     private fun <A> selectSubscribeInternal(
         owner: LifecycleOwner?,
@@ -209,22 +197,19 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      * Subscribe to changes in an async property. There are optional parameters for onSuccess
      * and onFail which automatically unwrap the value or error.
      */
-    internal fun <T> asyncSubscribe(
-        owner: LifecycleOwner,
-        asyncProp: KProperty1<S, Async<T>>,
-        onFail: ((Throwable) -> Unit)? = null,
-        onSuccess: ((T) -> Unit)? = null
-    ) = asyncSubscribeInternal(owner, asyncProp, onFail, onSuccess)
-
-    /**
-     * Subscribe to changes in an async property. There are optional parameters for onSuccess
-     * and onFail which automatically unwrap the value or error.
-     */
     protected fun <T> asyncSubscribe(
         asyncProp: KProperty1<S, Async<T>>,
         onFail: ((Throwable) -> Unit)? = null,
         onSuccess: ((T) -> Unit)? = null
     ) = asyncSubscribeInternal(null, asyncProp, onFail, onSuccess)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun <T> asyncSubscribe(
+        owner: LifecycleOwner,
+        asyncProp: KProperty1<S, Async<T>>,
+        onFail: ((Throwable) -> Unit)? = null,
+        onSuccess: ((T) -> Unit)? = null
+    ) = asyncSubscribeInternal(owner, asyncProp, onFail, onSuccess)
 
     private fun <T> asyncSubscribeInternal(
         owner: LifecycleOwner?,
@@ -242,21 +227,20 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for two properties.
      */
-    internal fun <A, B> selectSubscribe(
+    protected fun <A, B> selectSubscribe(
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        subscriber: (A, B) -> Unit
+    ) = selectSubscribeInternal(null, prop1, prop2, subscriber)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun <A, B> selectSubscribe(
         owner: LifecycleOwner,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         subscriber: (A, B) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, subscriber)
 
-    /**
-     * Subscribe to state changes for two properties.
-     */
-    protected fun <A, B> selectSubscribe(
-        prop1: KProperty1<S, A>,
-        prop2: KProperty1<S, B>,
-        subscriber: (A, B) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, subscriber)
 
     private fun <A, B> selectSubscribeInternal(
         owner: LifecycleOwner?,
@@ -268,23 +252,21 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for three properties.
      */
-    internal fun <A, B, C> selectSubscribe(
-        owner: LifecycleOwner,
-        prop1: KProperty1<S, A>,
-        prop2: KProperty1<S, B>,
-        prop3: KProperty1<S, C>,
-        subscriber: (A, B, C) -> Unit
-    ) = selectSubscribeInternal(owner, prop1, prop2, prop3, subscriber)
-
-    /**
-     * Subscribe to state changes for three properties.
-     */
     protected fun <A, B, C> selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
         subscriber: (A, B, C) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, prop3, subscriber)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun <A, B, C> selectSubscribe(
+        owner: LifecycleOwner,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        subscriber: (A, B, C) -> Unit
+    ) = selectSubscribeInternal(owner, prop1, prop2, prop3, subscriber)
 
     private fun <A, B, C> selectSubscribeInternal(
         owner: LifecycleOwner?,
@@ -294,7 +276,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         subscriber: (A, B, C) -> Unit
     ) = subscribeLifecycle(owner, propertyWhitelist(prop1, prop2, prop3)) { subscriber(prop1.get(it), prop2.get(it), prop3.get(it)) }
 
-    @Suppress("FunctionName")
     private fun subscribeLifecycle(
         lifecycleOwner: LifecycleOwner? = null,
         shouldUpdate: ((S, S) -> Boolean)? = null,


### PR DESCRIPTION
These should only be used by MvRxView which passes in itself as the owner.

They can't be internal because MvRxView calls them from an inline function.

I also removed the docs from them because they were redundant with the protected version and are now internal only.