### PR TITLE
Use tuples for selectSubscribe

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
@@ -29,13 +29,12 @@ import kotlin.reflect.full.isSupertypeOf
  */
 inline fun <T, VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.fragmentViewModel(
     viewModelClass: KClass<VM>,
-    noinline shouldUpdate: ((S, S) -> Boolean)? = null,
     crossinline keyFactory: () -> String = { viewModelClass.java.name }
 ) where T : Fragment,
         T : MvRxView = lazy {
     val stateFactory: () -> S = ::_fragmentViewModelInitialStateProvider
     MvRxViewModelProvider.get(viewModelClass, this, keyFactory(), stateFactory)
-        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { invalidate() }) }
+        .apply { subscribe(requireActivity(), subscriber = { invalidate() }) }
 }
 
 /**
@@ -44,13 +43,12 @@ inline fun <T, VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.fragmentViewM
  */
 fun <T, VM : BaseMvRxViewModel<S>, S : MvRxState> T.existingViewModel(
     viewModelClass: KClass<VM>,
-    shouldUpdate: ((S, S) -> Boolean)? = null,
     keyFactory: () -> String = { viewModelClass.java.name }
 ) where T : Fragment,
         T : MvRxView = lazy {
     val factory = MvRxFactory { throw IllegalStateException("ViewModel for ${requireActivity()}[${keyFactory()}] does not exist yet!") }
     ViewModelProviders.of(requireActivity(), factory).get(keyFactory(), viewModelClass.java)
-        .apply { subscribe(requireActivity(), shouldUpdate = shouldUpdate, subscriber = { invalidate() }) }
+        .apply { subscribe(requireActivity(), subscriber = { invalidate() }) }
 }
 
 /**
@@ -62,14 +60,13 @@ fun <T, VM : BaseMvRxViewModel<S>, S : MvRxState> T.existingViewModel(
  */
 inline fun <T, VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.activityViewModel(
     viewModelClass: KClass<VM>,
-    noinline shouldUpdate: ((S, S) -> Boolean)? = null,
     noinline keyFactory: () -> String = { viewModelClass.java.name }
 ) where T : Fragment,
         T : MvRxView = lazy {
     val stateFactory: () -> S = { _activityViewModelInitialStateProvider(keyFactory) }
     if (requireActivity() !is MvRxViewModelStoreOwner) throw IllegalArgumentException("Your Activity must be a MvRxViewModelStoreOwner!")
     MvRxViewModelProvider.get(viewModelClass, requireActivity(), keyFactory(), stateFactory)
-        .apply { subscribe(this@activityViewModel, shouldUpdate = shouldUpdate, subscriber = { invalidate() }) }
+        .apply { subscribe(this@activityViewModel, subscriber = { invalidate() }) }
 }
 
 /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTuples.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTuples.kt
@@ -1,0 +1,6 @@
+package com.airbnb.mvrx
+
+data class MvRxTuple1<A>(val a: A)
+data class MvRxTuple2<A, B>(val a: A, val b: B)
+data class MvRxTuple3<A, B, C>(val a: A, val b: B, val c: C)
+data class MvRxTuple4<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -20,9 +20,8 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * Use shouldUpdate if you only want to subscribe to a subset of all updates. There are some standard ones in ShouldUpdateHelpers.
      */
     fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(
-            shouldUpdate: ((S, S) -> Boolean)? = null,
             subscriber: ((S) -> Unit)? = null
-    ) = subscribe(this@MvRxView, shouldUpdate, subscriber ?: { invalidate() })
+    ) = subscribe(this@MvRxView, subscriber ?: { invalidate() })
 
     /**
      * Subscribes to state changes for only a specific property and calls the subscribe with
@@ -31,9 +30,7 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
     fun <S : MvRxState, A> BaseMvRxViewModel<S>.selectSubscribe(
             prop1: KProperty1<S, A>,
             subscriber: (A) -> Unit
-    ) = subscribe(this@MvRxView, propertyWhitelist(prop1)) {
-        subscriber(prop1.get(it))
-    }
+    ) = selectSubscribe(this@MvRxView, prop1, subscriber)
 
     /**
      * Subscribe to changes in an async property. There are optional parameters for onSuccess
@@ -46,27 +43,32 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
     ) = asyncSubscribe(this@MvRxView, asyncProp, onFail, onSuccess)
 
     /**
-     * Subscribes to state changes for two specific properties and calls the subscribe with
-     * both properties.
+     * Subscribes to state changes for two properties.
      */
     fun <S : MvRxState, A, B> BaseMvRxViewModel<S>.selectSubscribe(
             prop1: KProperty1<S, A>,
             prop2: KProperty1<S, B>,
             subscriber: (A, B) -> Unit
-    ) = subscribe(this@MvRxView, propertyWhitelist(prop1, prop2)) {
-        subscriber(prop1.get(it), prop2.get(it))
-    }
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, subscriber)
 
     /**
-     * Subscribes to state changes for two specific properties and calls the subscribe with
-     * both properties.
+     * Subscribes to state changes for three properties.
      */
     fun <S : MvRxState, A, B, C> BaseMvRxViewModel<S>.selectSubscribe(
             prop1: KProperty1<S, A>,
             prop2: KProperty1<S, B>,
             prop3: KProperty1<S, C>,
             subscriber: (A, B, C) -> Unit
-    ) = subscribe(this@MvRxView, propertyWhitelist(prop1, prop2, prop3)) {
-        subscriber(prop1.get(it), prop2.get(it), prop3.get(it))
-    }
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, subscriber)
+
+    /**
+     * Subscribes to state changes for four properties.
+     */
+    fun <S : MvRxState, A, B, C, D> BaseMvRxViewModel<S>.selectSubscribe(
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        prop4: KProperty1<S, D>,
+        subscriber: (A, B, C, D) -> Unit
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, subscriber)
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -76,33 +76,22 @@ class ViewModelSubscriberTest : BaseTest() {
 
     @Test
     fun testSelectSubscribe() {
-        assertEquals(0, viewModel.selectSubscribe1Called)
+        assertEquals(1, viewModel.selectSubscribe1Called)
     }
 
     @Test
     fun testSelectSubscribe1External() {
         var callCount = 0
         viewModel.selectSubscribe(owner, ViewModelTestState::foo) { callCount++ }
-        assertEquals(0, callCount)
-        viewModel.setFoo(1)
         assertEquals(1, callCount)
+        viewModel.setFoo(1)
+        assertEquals(2, callCount)
     }
 
     @Test
     fun testNotChangingFoo() {
         viewModel.setFoo(0)
         assertEquals(1, viewModel.subscribeCallCount)
-        assertEquals(0, viewModel.selectSubscribe1Called)
-        assertEquals(0, viewModel.selectSubscribe2Called)
-        assertEquals(0, viewModel.selectSubscribe3Called)
-        assertEquals(0, viewModel.onSuccessCalled)
-        assertEquals(0, viewModel.onFailCalled)
-    }
-
-    @Test
-    fun testChangingFoo() {
-        viewModel.setFoo(1)
-        assertEquals(2, viewModel.subscribeCallCount)
         assertEquals(1, viewModel.selectSubscribe1Called)
         assertEquals(1, viewModel.selectSubscribe2Called)
         assertEquals(1, viewModel.selectSubscribe3Called)
@@ -111,12 +100,23 @@ class ViewModelSubscriberTest : BaseTest() {
     }
 
     @Test
+    fun testChangingFoo() {
+        viewModel.setFoo(1)
+        assertEquals(2, viewModel.subscribeCallCount)
+        assertEquals(2, viewModel.selectSubscribe1Called)
+        assertEquals(2, viewModel.selectSubscribe2Called)
+        assertEquals(2, viewModel.selectSubscribe3Called)
+        assertEquals(0, viewModel.onSuccessCalled)
+        assertEquals(0, viewModel.onFailCalled)
+    }
+
+    @Test
     fun testChangingBar() {
         viewModel.setBar(1)
         assertEquals(2, viewModel.subscribeCallCount)
-        assertEquals(0, viewModel.selectSubscribe1Called)
-        assertEquals(1, viewModel.selectSubscribe2Called)
-        assertEquals(1, viewModel.selectSubscribe3Called)
+        assertEquals(1, viewModel.selectSubscribe1Called)
+        assertEquals(2, viewModel.selectSubscribe2Called)
+        assertEquals(2, viewModel.selectSubscribe3Called)
         assertEquals(0, viewModel.onSuccessCalled)
         assertEquals(0, viewModel.onFailCalled)
     }
@@ -125,9 +125,9 @@ class ViewModelSubscriberTest : BaseTest() {
     fun testChangingBam() {
         viewModel.setBam(1)
         assertEquals(2, viewModel.subscribeCallCount)
-        assertEquals(0, viewModel.selectSubscribe1Called)
-        assertEquals(0, viewModel.selectSubscribe2Called)
-        assertEquals(1, viewModel.selectSubscribe3Called)
+        assertEquals(1, viewModel.selectSubscribe1Called)
+        assertEquals(1, viewModel.selectSubscribe2Called)
+        assertEquals(2, viewModel.selectSubscribe3Called)
         assertEquals(0, viewModel.onSuccessCalled)
         assertEquals(0, viewModel.onFailCalled)
     }
@@ -136,9 +136,9 @@ class ViewModelSubscriberTest : BaseTest() {
     fun testSuccess() {
         viewModel.setAsync(Success("Hello World"))
         assertEquals(2, viewModel.subscribeCallCount)
-        assertEquals(0, viewModel.selectSubscribe1Called)
-        assertEquals(0, viewModel.selectSubscribe2Called)
-        assertEquals(0, viewModel.selectSubscribe3Called)
+        assertEquals(1, viewModel.selectSubscribe1Called)
+        assertEquals(1, viewModel.selectSubscribe2Called)
+        assertEquals(1, viewModel.selectSubscribe3Called)
         assertEquals(1, viewModel.onSuccessCalled)
         assertEquals(0, viewModel.onFailCalled)
     }
@@ -147,9 +147,9 @@ class ViewModelSubscriberTest : BaseTest() {
     fun testFail() {
         viewModel.setAsync(Fail(IllegalStateException("foo")))
         assertEquals(2, viewModel.subscribeCallCount)
-        assertEquals(0, viewModel.selectSubscribe1Called)
-        assertEquals(0, viewModel.selectSubscribe2Called)
-        assertEquals(0, viewModel.selectSubscribe3Called)
+        assertEquals(1, viewModel.selectSubscribe1Called)
+        assertEquals(1, viewModel.selectSubscribe2Called)
+        assertEquals(1, viewModel.selectSubscribe3Called)
         assertEquals(0, viewModel.onSuccessCalled)
         assertEquals(1, viewModel.onFailCalled)
     }

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexFragment.kt
@@ -31,10 +31,10 @@ class DadJokeIndexFragment : BaseFragment() {
          * function that is given the old state and new state and returns whether or not to
          * call the subscriber. onSuccess, onFail, and propertyWhitelist ship with MvRx.
          */
-        viewModel.subscribe(onFail(DadJokeIndexState::request)) {
+        viewModel.asyncSubscribe(DadJokeIndexState::request, onFail = { error ->
             Snackbar.make(coordinatorLayout, "Jokes request failed.", Snackbar.LENGTH_INDEFINITE).show()
-            Log.w(TAG, "Jokes request failed", (it.request as Fail<*>).error)
-        }
+            Log.w(TAG, "Jokes request failed", error)
+        })
     }
 
     override fun EpoxyController.buildModels() = withState(viewModel) { state ->

--- a/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/core/BaseFragment.kt
+++ b/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/core/BaseFragment.kt
@@ -73,11 +73,9 @@ abstract class BaseFragment : BaseMvRxFragment() {
             oldTasks = tasks
         }
 
-        viewModel.subscribe(propertyWhitelist(TasksState::isLoading)) { state ->
-            if (state.taskRequest is Error) {
-                coordinatorLayout.showLongSnackbar(R.string.loading_tasks_error)
-            }
-        }
+        viewModel.asyncSubscribe(TasksState::taskRequest, onFail = {
+            coordinatorLayout.showLongSnackbar(R.string.loading_tasks_error)
+        })
     }
 
     override fun invalidate() {


### PR DESCRIPTION
Migrates selectSubscribe to use a tuple with distinctUntilChanged. This is a silent API change that will now immediately deliver the initial value. The updated tests reflect this new behavior.

This also works without scan or ever looking at oldState which is great.

This supersedes #41 

Thanks @hellohuanlin and @BenSchwab for raising some good discussions that led to this

@BenSchwab @hellohuanlin 