### PR TITLE
postInvalidate in onStart()

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -21,4 +21,11 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
         super.onSaveInstanceState(outState)
         mvrxViewModelStore.saveViewModels(outState)
     }
+
+    override fun onStart() {
+        super.onStart()
+        // This ensures that invalidate() is called for static screens that don't
+        // subscribe to a ViewModel.
+        postInvalidate()
+    }
 }

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldFragment.kt
@@ -8,14 +8,10 @@ import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.airbnb.mvrx.BaseMvRxFragment
-import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.sample.R
 import com.airbnb.mvrx.sample.views.Marquee
-import com.airbnb.mvrx.withState
 
 class HelloWorldFragment : BaseMvRxFragment() {
-    private val viewModel: HelloWorldViewModel by fragmentViewModel()
-
     private lateinit var marquee: Marquee
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
@@ -24,7 +20,7 @@ class HelloWorldFragment : BaseMvRxFragment() {
             marquee = findViewById(R.id.marquee)
         }
 
-    override fun invalidate() = withState(viewModel) { state ->
-        marquee.setTitle(state.title)
+    override fun invalidate() {
+        marquee.setTitle("Hello World")
     }
 }


### PR DESCRIPTION
Now that we dedupe invalidations, this enables static screens to be invalidated even if they don't subscribe to a view model