### PR TITLE
Update Epoxy sample pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.supportLibVersion = '27.1.1'
     ext.lifecycleVersion = '1.1.1'
     ext.robolectricVersion = '3.8'
-    ext.epoxyVersion = '2.16.0'
+    ext.epoxyVersion = '2.16.4'
     ext.moshiVersion = '1.6.0'
     ext.koinVersion = '0.9.3'
     ext.retrofitVersion = '2.4.0'

--- a/sample/src/main/java/com/airbnb/mvrx/sample/MainFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/MainFragment.kt
@@ -1,13 +1,13 @@
 package com.airbnb.mvrx.sample
 
-import com.airbnb.epoxy.EpoxyController
 import com.airbnb.mvrx.sample.core.BaseFragment
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.views.basicRow
 import com.airbnb.mvrx.sample.views.marquee
 
 class MainFragment : BaseFragment() {
 
-    override fun EpoxyController.buildModels() {
+    override fun epoxyController() = simpleController {
         marquee {
             id("marquee")
             title("Welcome to MvRx")
@@ -38,17 +38,31 @@ class MainFragment : BaseFragment() {
         basicRow {
             id("dad_jokes")
             title("Dad Jokes")
-            subtitle(demonstrates("fragmentViewModel", "Fragment arguments", "Network requests", "Pagination", "Dependency Injection"))
+            subtitle(
+                demonstrates(
+                    "fragmentViewModel",
+                    "Fragment arguments",
+                    "Network requests",
+                    "Pagination",
+                    "Dependency Injection"
+                )
+            )
             clickListener { _ -> navigateTo(R.id.action_mainFragment_to_dadJokeIndex) }
         }
 
         basicRow {
             id("flow")
             title("Flow")
-            subtitle(demonstrates("Sharing data across screens", "activityViewModel and existingViewModel"))
+            subtitle(
+                demonstrates(
+                    "Sharing data across screens",
+                    "activityViewModel and existingViewModel"
+                )
+            )
             clickListener { _ -> navigateTo(R.id.action_main_to_flowIntroFragment) }
         }
     }
 
-    private fun demonstrates(vararg items: String) = arrayOf("Demonstrates:", *items).joinToString("\n\t\t• ")
+    private fun demonstrates(vararg items: String) =
+        arrayOf("Demonstrates:", *items).joinToString("\n\t\t• ")
 }

--- a/sample/src/main/java/com/airbnb/mvrx/sample/core/MvrxEpoxyController.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/core/MvrxEpoxyController.kt
@@ -1,0 +1,96 @@
+package com.airbnb.mvrx.sample.core
+
+import android.os.Bundle
+import com.airbnb.epoxy.AsyncEpoxyController
+import com.airbnb.epoxy.EpoxyController
+import com.airbnb.mvrx.BaseMvRxViewModel
+import com.airbnb.mvrx.MvRxState
+import com.airbnb.mvrx.withState
+
+
+/**
+ * For use with [BaseFragment.epoxyController].
+ *
+ * This builds Epoxy models in a background thread.
+ */
+open class MvRxEpoxyController(
+    val buildModelsCallback: EpoxyController.() -> Unit = {}
+) : AsyncEpoxyController() {
+
+    override fun buildModels() {
+        buildModelsCallback()
+    }
+
+    override fun onRestoreInstanceState(inState: Bundle?) {
+        // In Epoxy, you normally own your adapter and save it as a field so you can safely call onSave and onRestoreInstanceState.
+        // MvRx provides an epoxy controller by default but allows it to be manually set. In onSaveInstanceState, we query the RecyclerView
+        // for its adapter and save its state. This works unless onDestroyView was called first in which case the adapter gets cleared.
+        // This happens if onSaveInstanceState is called while a Fragment is on the back stack.
+        // In this case, when return, savedInstanceState will be called with a non-null bundle but the epoxy state was never saved.
+        // Epoxy crashes in this case because it's normally a sign that you forgot to save the state. However, in this case, it happens because
+        // we don't own the EpoxyController.
+        // This does the hacky thing of checking for the epoxy key because Epoxy has no way of handling this since. TBD if it is something
+        // it should support.
+        if (inState?.containsKey("saved_state_view_holders") == true) {
+            super.onRestoreInstanceState(inState)
+        }
+    }
+}
+
+
+/**
+ * Create a [MvRxEpoxyController] that builds models with the given callback.
+ */
+fun BaseFragment.simpleController(
+    buildModels: EpoxyController.() -> Unit
+) = MvRxEpoxyController {
+    // Models are built asynchronously, so it is possible that this is called after the fragment
+    // is detached under certain race conditions.
+    if (view == null || isRemoving) return@MvRxEpoxyController
+    buildModels()
+}
+
+/**
+ * Create a [MvRxEpoxyController] that builds models with the given callback.
+ * When models are built the current state of the viewmodel will be provided.
+ */
+fun <S : MvRxState, A : MvRxViewModel<S>> BaseFragment.simpleController(
+    viewModel: A,
+    buildModels: EpoxyController.(state: S) -> Unit
+) = MvRxEpoxyController {
+    if (view == null || isRemoving) return@MvRxEpoxyController
+    withState(viewModel) { state ->
+        buildModels(state)
+    }
+}
+
+/**
+ * Create a [MvRxEpoxyController] that builds models with the given callback.
+ * When models are built the current state of the viewmodels will be provided.
+ */
+fun <A : BaseMvRxViewModel<B>, B : MvRxState, C : BaseMvRxViewModel<D>, D : MvRxState> BaseFragment.simpleController(
+    viewModel1: A,
+    viewModel2: C,
+    buildModels: EpoxyController.(state1: B, state2: D) -> Unit
+) = MvRxEpoxyController {
+    if (view == null || isRemoving) return@MvRxEpoxyController
+    withState(viewModel1, viewModel2) { state1, state2 ->
+        buildModels(state1, state2)
+    }
+}
+
+/**
+ * Create a [MvRxEpoxyController] that builds models with the given callback.
+ * When models are built the current state of the viewmodels will be provided.
+ */
+fun <A : BaseMvRxViewModel<B>, B : MvRxState, C : BaseMvRxViewModel<D>, D : MvRxState, E : BaseMvRxViewModel<F>, F : MvRxState> BaseFragment.simpleController(
+    viewModel1: A,
+    viewModel2: C,
+    viewModel3: E,
+    buildModels: EpoxyController.(state1: B, state2: D, state3: F) -> Unit
+) = MvRxEpoxyController {
+    if (view == null || isRemoving) return@MvRxEpoxyController
+    withState(viewModel1, viewModel2, viewModel3) { state1, state2, state3 ->
+        buildModels(state1, state2, state3)
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeDetailFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeDetailFragment.kt
@@ -3,21 +3,15 @@ package com.airbnb.mvrx.sample.features.dadjoke
 import android.annotation.SuppressLint
 import android.os.Parcelable
 import android.support.v4.app.FragmentActivity
-import com.airbnb.epoxy.EpoxyController
-import com.airbnb.mvrx.Async
-import com.airbnb.mvrx.BaseMvRxViewModel
-import com.airbnb.mvrx.MvRxState
-import com.airbnb.mvrx.MvRxViewModelFactory
-import com.airbnb.mvrx.Uninitialized
-import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.*
 import com.airbnb.mvrx.sample.core.BaseFragment
 import com.airbnb.mvrx.sample.core.MvRxViewModel
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.models.Joke
 import com.airbnb.mvrx.sample.network.DadJokeService
 import com.airbnb.mvrx.sample.views.basicRow
 import com.airbnb.mvrx.sample.views.loadingRow
 import com.airbnb.mvrx.sample.views.marquee
-import com.airbnb.mvrx.withState
 import kotlinx.android.parcel.Parcelize
 import org.koin.android.ext.android.inject
 
@@ -33,7 +27,10 @@ data class DadJokeDetailState(val id: String, val joke: Async<Joke> = Uninitiali
     constructor(args: DadJokeDetailArgs) : this(id = args.id)
 }
 
-class DadJokeDetailViewModel(initialState: DadJokeDetailState, private val dadJokeService: DadJokeService) : MvRxViewModel<DadJokeDetailState>(initialState) {
+class DadJokeDetailViewModel(
+    initialState: DadJokeDetailState,
+    private val dadJokeService: DadJokeService
+) : MvRxViewModel<DadJokeDetailState>(initialState) {
 
     init {
         fetchJoke()
@@ -45,7 +42,11 @@ class DadJokeDetailViewModel(initialState: DadJokeDetailState, private val dadJo
     }
 
     companion object : MvRxViewModelFactory<DadJokeDetailState> {
-        @JvmStatic override fun create(activity: FragmentActivity, state: DadJokeDetailState): BaseMvRxViewModel<DadJokeDetailState> {
+        @JvmStatic
+        override fun create(
+            activity: FragmentActivity,
+            state: DadJokeDetailState
+        ): BaseMvRxViewModel<DadJokeDetailState> {
             val service: DadJokeService by activity.inject()
             return DadJokeDetailViewModel(state, service)
         }
@@ -55,7 +56,7 @@ class DadJokeDetailViewModel(initialState: DadJokeDetailState, private val dadJo
 class DadJokeDetailFragment : BaseFragment() {
     private val viewModel: DadJokeDetailViewModel by fragmentViewModel()
 
-    override fun EpoxyController.buildModels() = withState(viewModel) { state ->
+    override fun epoxyController() = simpleController(viewModel) { state ->
         marquee {
             id("marquee")
             title("Dad Joke")
@@ -70,7 +71,7 @@ class DadJokeDetailFragment : BaseFragment() {
             loadingRow {
                 id("loading")
             }
-            return@withState
+            return@simpleController
         }
 
         basicRow {

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexFragment.kt
@@ -4,16 +4,16 @@ import android.os.Bundle
 import android.support.design.widget.Snackbar
 import android.util.Log
 import android.view.View
-import com.airbnb.epoxy.EpoxyController
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.sample.R
 import com.airbnb.mvrx.sample.core.BaseFragment
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.views.basicRow
 import com.airbnb.mvrx.sample.views.loadingRow
 import com.airbnb.mvrx.sample.views.marquee
-import com.airbnb.mvrx.withState
 
 private const val TAG = "DadJokeIndexFragment"
+
 class DadJokeIndexFragment : BaseFragment() {
 
     /**
@@ -30,12 +30,13 @@ class DadJokeIndexFragment : BaseFragment() {
          * call the subscriber. onSuccess, onFail, and propertyWhitelist ship with MvRx.
          */
         viewModel.asyncSubscribe(DadJokeIndexState::request, onFail = { error ->
-            Snackbar.make(coordinatorLayout, "Jokes request failed.", Snackbar.LENGTH_INDEFINITE).show()
+            Snackbar.make(coordinatorLayout, "Jokes request failed.", Snackbar.LENGTH_INDEFINITE)
+                .show()
             Log.w(TAG, "Jokes request failed", error)
         })
     }
 
-    override fun EpoxyController.buildModels() = withState(viewModel) { state ->
+    override fun epoxyController() = simpleController(viewModel) { state ->
         marquee {
             id("marquee")
             title("Dad Jokes")
@@ -45,7 +46,12 @@ class DadJokeIndexFragment : BaseFragment() {
             basicRow {
                 id(joke.id)
                 title(joke.joke)
-                clickListener { _ -> navigateTo(R.id.action_dadJokeIndex_to_dadJokeDetailFragment, DadJokeDetailArgs(joke.id)) }
+                clickListener { _ ->
+                    navigateTo(
+                        R.id.action_dadJokeIndex_to_dadJokeDetailFragment,
+                        DadJokeDetailArgs(joke.id)
+                    )
+                }
             }
         }
 

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/RandomDadJokeFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/RandomDadJokeFragment.kt
@@ -1,28 +1,22 @@
 package com.airbnb.mvrx.sample.features.dadjoke
 
 import android.support.v4.app.FragmentActivity
-import com.airbnb.epoxy.EpoxyController
-import com.airbnb.mvrx.Async
-import com.airbnb.mvrx.BaseMvRxViewModel
-import com.airbnb.mvrx.MvRxState
-import com.airbnb.mvrx.MvRxViewModelFactory
-import com.airbnb.mvrx.Uninitialized
-import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.*
 import com.airbnb.mvrx.sample.core.BaseFragment
 import com.airbnb.mvrx.sample.core.MvRxViewModel
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.models.Joke
 import com.airbnb.mvrx.sample.network.DadJokeService
 import com.airbnb.mvrx.sample.views.basicRow
 import com.airbnb.mvrx.sample.views.loadingRow
 import com.airbnb.mvrx.sample.views.marquee
-import com.airbnb.mvrx.withState
 import org.koin.android.ext.android.inject
 
 data class RandomDadJokeState(val joke: Async<Joke> = Uninitialized) : MvRxState
 
 class RandomDadJokeViewModel(
-        initialState: RandomDadJokeState,
-        private val dadJokeService: DadJokeService
+    initialState: RandomDadJokeState,
+    private val dadJokeService: DadJokeService
 ) : MvRxViewModel<RandomDadJokeState>(initialState) {
     init {
         fetchRandomJoke()
@@ -33,7 +27,11 @@ class RandomDadJokeViewModel(
     }
 
     companion object : MvRxViewModelFactory<RandomDadJokeState> {
-        @JvmStatic override fun create(activity: FragmentActivity, state: RandomDadJokeState): BaseMvRxViewModel<RandomDadJokeState> {
+        @JvmStatic
+        override fun create(
+            activity: FragmentActivity,
+            state: RandomDadJokeState
+        ): BaseMvRxViewModel<RandomDadJokeState> {
             val service: DadJokeService by activity.inject()
             return RandomDadJokeViewModel(state, service)
         }
@@ -41,10 +39,9 @@ class RandomDadJokeViewModel(
 }
 
 class RandomDadJokeFragment : BaseFragment() {
-    private val viewModel : RandomDadJokeViewModel by fragmentViewModel()
+    private val viewModel: RandomDadJokeViewModel by fragmentViewModel()
 
-
-    override fun EpoxyController.buildModels() = withState(viewModel) { state ->
+    override fun epoxyController() = simpleController(viewModel) { state ->
         marquee {
             id("marquee")
             title("Dad Joke")
@@ -59,7 +56,7 @@ class RandomDadJokeFragment : BaseFragment() {
             loadingRow {
                 id("loading")
             }
-            return@withState
+            return@simpleController
         }
 
         basicRow {

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/flow/FlowCounterFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/flow/FlowCounterFragment.kt
@@ -1,10 +1,9 @@
 package com.airbnb.mvrx.sample.features.flow
 
-import com.airbnb.epoxy.EpoxyController
 import com.airbnb.mvrx.existingViewModel
 import com.airbnb.mvrx.sample.core.BaseFragment
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.views.marquee
-import com.airbnb.mvrx.withState
 
 class FlowCounterFragment : BaseFragment() {
     /**
@@ -16,7 +15,7 @@ class FlowCounterFragment : BaseFragment() {
      */
     private val viewModel by existingViewModel(FlowViewModel::class)
 
-    override fun EpoxyController.buildModels() = withState(viewModel) { state ->
+    override fun epoxyController() = simpleController(viewModel) { state ->
         marquee {
             id("marquee")
             title("Counter: ${state.count}")

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/flow/FlowIntroFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/flow/FlowIntroFragment.kt
@@ -1,10 +1,10 @@
 package com.airbnb.mvrx.sample.features.flow
 
 import androidx.navigation.fragment.findNavController
-import com.airbnb.epoxy.EpoxyController
 import com.airbnb.mvrx.activityViewModel
 import com.airbnb.mvrx.sample.R
 import com.airbnb.mvrx.sample.core.BaseFragment
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.views.basicRow
 import com.airbnb.mvrx.sample.views.marquee
 
@@ -12,7 +12,7 @@ class FlowIntroFragment : BaseFragment() {
 
     private val viewModel by activityViewModel(FlowViewModel::class)
 
-    override fun EpoxyController.buildModels() {
+    override fun epoxyController() = simpleController {
         marquee {
             id("marquee")
             title("Intro")

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldEpoxyFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldEpoxyFragment.kt
@@ -1,15 +1,14 @@
 package com.airbnb.mvrx.sample.features.helloworld
 
-import com.airbnb.epoxy.EpoxyController
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.sample.core.BaseFragment
+import com.airbnb.mvrx.sample.core.simpleController
 import com.airbnb.mvrx.sample.views.marquee
-import com.airbnb.mvrx.withState
 
 class HelloWorldEpoxyFragment : BaseFragment() {
     private val viewModel: HelloWorldViewModel by fragmentViewModel()
 
-    override fun EpoxyController.buildModels() = withState(viewModel) { state ->
+    override fun epoxyController() = simpleController(viewModel) { state ->
         marquee {
             id("marquee")
             title(state.title)


### PR DESCRIPTION
This updates the epoxy usage in the sample app to be similar to what we have in the Airbnb app. Instead of a `buildModels` function to override you provide an epoxyController. I have also added helper functions for this.

Additionally, this adds state saving to the epoxy controller, and makes it build models and diff asynchronously.

I've also updated the wiki with a new Epoxy page - https://github.com/airbnb/MvRx/wiki/Epoxy-&-MvRx