### PR TITLE
adding google() repository before jcenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
     ext.roomVersion = "1.1.1"
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'


### PR DESCRIPTION
jcenter was started to mirror repositories of google. If we want to use latest version of google, we should change the order of repositories.

I could not find any blog post about it but related tweets are :
https://twitter.com/eenriquelopez/status/1005055558255120385
https://twitter.com/andremion/status/1005373704765870081