### PR TITLE
Potential approaches for allowing mocked state

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -10,6 +10,7 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
+import io.reactivex.disposables.Disposables
 import io.reactivex.functions.Consumer
 import io.reactivex.schedulers.Schedulers
 import kotlin.reflect.KProperty1
@@ -22,12 +23,13 @@ import kotlin.reflect.KVisibility
  */
 abstract class BaseMvRxViewModel<S : MvRxState>(
     initialState: S,
-    private val debugMode: Boolean = false
+    private val debugMode: Boolean = false,
+    mocker: ViewModelMocker<S>? = null
 ) : ViewModel() {
     private val tag by lazy { javaClass.simpleName }
     private val disposables = CompositeDisposable()
     private val backgroundScheduler = Schedulers.single()
-    private val stateStore: MvRxStateStore<S> = MvRxStateStore(initialState)
+    private val stateStore: MvRxStateStore<S> = MvRxStateStore(initialState, mocker)
 
     init {
         if (debugMode) {
@@ -57,17 +59,16 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      *    mutable variables or properties from outside the lambda or else it may crash.
      */
     protected fun setState(reducer: S.() -> S) {
-        if (debugMode) {
-            // Must use `set` to ensure the validated state is the same as the actual state used in reducer
-            // Do not use `get` since `getState` queue has lower priority and the validated state would be the state after reduced
-            stateStore.set {
-                val firstState = this.reducer()
-                val secondState = this.reducer()
-                if (firstState != secondState) throw IllegalArgumentException("Your reducer must be pure!")
-                firstState
-            }
-        } else {
-            stateStore.set(reducer)
+        when {
+            debugMode -> // Must use `set` to ensure the validated state is the same as the actual state used in reducer
+                // Do not use `get` since `getState` queue has lower priority and the validated state would be the state after reduced
+                stateStore.set {
+                    val firstState = this.reducer()
+                    val secondState = this.reducer()
+                    if (firstState != secondState) throw IllegalArgumentException("Your reducer must be pure!")
+                    firstState
+                }
+            else -> stateStore.set(reducer)
         }
     }
 
@@ -137,6 +138,10 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         successMetaData: ((T) -> Any)? = null,
         stateReducer: S.(Async<V>) -> S
     ): Disposable {
+        if (stateStore.isMocked) {
+            return Disposables.disposed()
+        }
+
         // This will ensure that Loading is dispatched immediately rather than being posted to `backgroundScheduler` before emitting Loading.
         setState { stateReducer(Loading()) }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -23,13 +23,12 @@ import kotlin.reflect.KVisibility
  */
 abstract class BaseMvRxViewModel<S : MvRxState>(
     initialState: S,
-    private val debugMode: Boolean = false,
-    mocker: ViewModelMocker<S>? = null
+    private val debugMode: Boolean = false
 ) : ViewModel() {
     private val tag by lazy { javaClass.simpleName }
     private val disposables = CompositeDisposable()
     private val backgroundScheduler = Schedulers.single()
-    private val stateStore: MvRxStateStore<S> = MvRxStateStore(initialState, mocker)
+    private val stateStore: MvRxStateStore<S> = MvRxStateStore(initialState)
 
     init {
         if (debugMode) {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/TestUtil.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/TestUtil.kt
@@ -1,0 +1,7 @@
+package com.airbnb.mvrx
+
+
+class ViewModelMocker<S : Any>(val stateProvider: () -> S)
+// TODO What is the best interface for getting the state? A callback, or a simple setter?
+// TODO Should initial state be mocked?
+// TODO Should this class invalidate the view when the state is changed?

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/TestUtil.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/TestUtil.kt
@@ -1,7 +1,23 @@
 package com.airbnb.mvrx
 
+import android.os.Parcelable
 
-class ViewModelMocker<S : Any>(val stateProvider: () -> S)
-// TODO What is the best interface for getting the state? A callback, or a simple setter?
-// TODO Should initial state be mocked?
-// TODO Should this class invalidate the view when the state is changed?
+
+object MvRxMocker {
+
+    var enabled: Boolean = false
+    private val mockedState: MutableMap<BaseMvRxViewModel<*>, Any> = mutableMapOf()
+
+     fun <S : MvRxState> setMockedState(viewModel: BaseMvRxViewModel<S>, state: S) {
+        mockedState[viewModel] = state
+    }
+
+     fun <S : MvRxState> setMockedStateFromArg(viewModel: BaseMvRxViewModel<S>, args: Parcelable) {
+        mockedState[viewModel] = TODO()
+    }
+
+
+    internal fun <S : MvRxState> getMockedState(viewModel: BaseMvRxViewModel<S>): S? {
+        return if (enabled) mockedState[viewModel] as S else null
+    }
+}


### PR DESCRIPTION
Playing with some ways to mock out state for testing. Each commit here is a separate approach.

Use an intermediate mocker singleton to control all mocked state
https://github.com/airbnb/MvRx/pull/72/commits/6ffc9c77be63994a3b1d83b446b2710f97db5d8f

Set a mock provider on the view model
https://github.com/airbnb/MvRx/pull/72/commits/d508554af7a894be4b220de14f1af4e18678a111

Definitely want to avoid making it too easy to set state so people don't use this outside of testing.