### PR TITLE
Remove subscribeOn and observeOn thread for observable execution

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -27,7 +27,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
 ) : ViewModel() {
     private val tag by lazy { javaClass.simpleName }
     private val disposables = CompositeDisposable()
-    private val backgroundScheduler = Schedulers.single()
     private lateinit var mutableStateChecker: MutableStateChecker<S>
 
     init {
@@ -144,7 +143,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         successMetaData: ((T) -> Any)? = null,
         stateReducer: S.(Async<V>) -> S
     ): Disposable {
-        // This will ensure that Loading is dispatched immediately rather than being posted to `backgroundScheduler` before emitting Loading.
         setState { stateReducer(Loading()) }
 
         return map {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -148,7 +148,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         setState { stateReducer(Loading()) }
 
         return observeOn(backgroundScheduler)
-            .subscribeOn(backgroundScheduler)
             .map {
                 val success = Success(mapper(it))
                 success.metadata = successMetaData?.invoke(it)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -147,8 +147,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         // This will ensure that Loading is dispatched immediately rather than being posted to `backgroundScheduler` before emitting Loading.
         setState { stateReducer(Loading()) }
 
-        return observeOn(backgroundScheduler)
-            .map {
+        return map {
                 val success = Success(mapper(it))
                 success.metadata = successMetaData?.invoke(it)
                 success as Async<V>


### PR DESCRIPTION
It can be unexpected to change upstream thread in VM. MvRx should only switch downstream thread. 

For example: 

```
// in thread A context
inMemoryDB
  .fetchStuffWhichIsFastOperation() // Developer intend to run it on thread A, we shouldn't run it on merge thread. (Assuming this function doesn't have a `subscribeOn`)
  .execute {
    // merge thread here, which is expected
  }
```

Also removed `observeOn(backgroundThread)`, since `setState` is thread safe, and it can be run on any thread. (Note that `setState` only enqueues the block, while the actual execution of block is still in merge thread. )

@gpeal @BenSchwab @elihart 
