### PR TITLE
Fix ordering issue of setState calls within withState 

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateStore.kt
@@ -5,7 +5,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
-import java.util.LinkedList
+import java.util.*
 
 /**
  * This is a container class around the actual state itself. It has a few optimizations to ensure
@@ -83,12 +83,12 @@ internal open class MvRxStateStore<S : Any>(initialState: S) : Disposable {
 
         @Synchronized
         fun enqueueGetStateBlock(block: (state: S) -> Unit) {
-            getStateQueue.push(block)
+            getStateQueue.add(block)
         }
 
         @Synchronized
         fun enqueueSetStateBlock(block: S.() -> S) {
-            setStateQueue.push(block)
+            setStateQueue.add(block)
         }
 
         @Synchronized
@@ -112,7 +112,7 @@ internal open class MvRxStateStore<S : Any>(initialState: S) : Disposable {
     /**
      * Flushes the setState and getState queues.
      *
-     * This will flush he setState queue then call the first element on the getState queue.
+     * This will flush the setState queue then call the first element on the getState queue.
      *
      * In case the setState queue calls setState, we call flushQueues recursively to flush the setState queue
      * in between every getState block gets processed.

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -10,8 +10,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.Semaphore
-import java.util.concurrent.TimeUnit
 
 data class ViewModelTestState(val foo: Int = 0, val bar: Int = 0, val bam: Int = 0, val list: List<Int> = emptyList(), val async: Async<String> = Uninitialized) : MvRxState
 class ViewModelTestViewModel(initialState: ViewModelTestState) : TestMvRxViewModel<ViewModelTestState>(initialState) {
@@ -101,6 +99,24 @@ class ViewModelTestViewModel(initialState: ViewModelTestState) : TestMvRxViewMod
         }
         Observable.just("Hello World").execute { copy(async = it) }
         assertEquals(3, callCount)
+    }
+
+    fun testSequentialSetStatesWithinWithStateBlock() {
+        var callCount = 0
+        withState {
+            selectSubscribe(ViewModelTestState::foo) {
+                callCount++
+                assertEquals(when (callCount) {
+                    1 -> 0
+                    2 -> 2
+                    else -> throw IllegalArgumentException("Unexpected call count $callCount")
+                }, it)
+            }
+            // These will be coalesced into one update
+            setState { copy(foo = 1) }
+            setState { copy(foo = 2) }
+        }
+        assertEquals(2, callCount)
     }
 
     fun testObservableFail() {
@@ -317,10 +333,14 @@ class ViewModelSubscriberTest : BaseTest() {
     }
 
     @Test
+    fun testSequentialSetStatesWithinWithStateBlock() {
+        viewModel.testSequentialSetStatesWithinWithStateBlock()
+    }
+
+    @Test
     fun testObservableWithMapper() {
         viewModel.testObservableWithMapper()
     }
-
 
     @Test
     fun testObservableFail() {


### PR DESCRIPTION
`push` adds to the front of the queue, but we want to add to the end to preserve order of `setState`. The only time the queue will have multiple elements is within a call to `withState`. This is because the `withState` block itself will be on the background thread, so `setState` calls will not run immediately. Currently this test fails with the value of `foo` on the second call being `1` as the ordering of the setState was reversed:

```
 withState {
            selectSubscribe(ViewModelTestState::foo) {
                callCount++
                assertEquals(when (callCount) {
                    1 -> 0
                    2 -> 2
                    else -> throw IllegalArgumentException("Unexpected call count $callCount")
                }, it)
            }
            // These will be coalesced into one update
            setState { copy(foo = 1) }
            setState { copy(foo = 2) }
        }
        assertEquals(2, callCount)
```

Now it passes. Note -- that this also tests the coalescing logic of setState's within with state.