### PR TITLE
Add debug validation for state immutability

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxMutabilityHelper.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxMutabilityHelper.kt
@@ -11,8 +11,10 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.starProjectedType
 
-private const val IMMUTABLE_LIST_MESSAGE = "Use the immutable listOf(...) method instead. You can append it with `val newList = listA + listB`"
-private const val IMMUTABLE_MAP_MESSAGE = "Use the immutable mapOf(...) method instead. You can append it with `val newMap = mapA + mapB`"
+private const val IMMUTABLE_LIST_MESSAGE =
+    "Use the immutable listOf(...) method instead. You can append it with `val newList = listA + listB`"
+private const val IMMUTABLE_MAP_MESSAGE =
+    "Use the immutable mapOf(...) method instead. You can append it with `val newMap = mapA + mapB`"
 
 /**
  * Ensures that the state class is immutable.
@@ -25,7 +27,8 @@ private const val IMMUTABLE_MAP_MESSAGE = "Use the immutable mapOf(...) method i
 internal fun KClass<*>.assertImmutability() {
     require(this.isData) { "MvRx state must be a data class!" }
 
-    fun KProperty1<*, *>.isSubtype(klass: KClass<*>) = returnType.isSubtypeOf(klass.starProjectedType)
+    fun KProperty1<*, *>.isSubtype(klass: KClass<*>) =
+        returnType.isSubtypeOf(klass.starProjectedType)
 
     this.declaredMemberProperties.forEach {
         when {
@@ -41,3 +44,31 @@ internal fun KClass<*>.assertImmutability() {
         }?.let { throw IllegalArgumentException(it) }
     }
 }
+
+/**
+ * Checks that a state's value is not changed over its lifetime.
+ */
+internal class MutableStateChecker<S : MvRxState>(val initialState: S) {
+
+    data class StateWrapper<S : MvRxState>(val state: S) {
+        private val originalHashCode = hashCode()
+
+        fun validate() = require(originalHashCode == hashCode()) {
+            "${state::class.java.simpleName} was mutated. State classes should be immutable."
+        }
+    }
+
+    private var previousState = StateWrapper(initialState)
+
+    /**
+     * Should be called whenever state changes. This validates that the hashcode of each state
+     * instance does not change between when it is first set and when the next state is set.
+     * If it does change it means different state instances share some mutable data structure.
+     */
+    fun onStateChanged(newState: S) {
+        previousState.validate()
+        previousState = StateWrapper(newState)
+    }
+}
+
+

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
@@ -69,8 +69,8 @@ class FactoryTest : BaseTest() {
 
     @Test(expected = IllegalArgumentException::class)
     fun failOnWrongSingleParameterType() {
-        class OptionalParamViewModel(initialState: String) : BaseMvRxViewModel<FactoryState>(initialState = FactoryState(), debugMode = false)
-        MvRxViewModelProvider.get(OptionalParamViewModel::class.java, activity) { FactoryState(count = 5) }
+        class ViewModel : BaseMvRxViewModel<FactoryState>(initialState = FactoryState(), debugMode = false)
+        MvRxViewModelProvider.get(ViewModel::class.java, activity) { FactoryState(count = 5) }
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/MutableStateValidationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/MutableStateValidationTest.kt
@@ -1,0 +1,40 @@
+package com.airbnb.mvrx
+
+import org.junit.Test
+
+
+data class StateWithMutableMap(val map: MutableMap<String, String> = mutableMapOf()) : MvRxState
+data class StateWithImmutableMap(val map: Map<String, String> = mapOf()) : MvRxState
+
+class MutableStateValidationTest : BaseTest() {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun mutableStateShouldFail() {
+        class ViewModel(initialState: StateWithMutableMap) :
+            TestMvRxViewModel<StateWithMutableMap>(initialState) {
+
+            fun addKeyToMap() {
+                val myMap = withState(this) { it.map }
+                myMap["foo"] = "bar"
+
+                setState { copy(map = myMap) }
+            }
+        }
+        ViewModel(StateWithMutableMap()).addKeyToMap()
+    }
+
+    @Test
+    fun immutableStateShouldNotFail() {
+        class ViewModel(initialState: StateWithImmutableMap) :
+            TestMvRxViewModel<StateWithImmutableMap>(initialState) {
+
+            fun addKeyToMap() {
+                val myMap = withState(this) { it.map }.toMutableMap()
+                myMap["foo"] = "bar"
+
+                setState { copy(map = myMap) }
+            }
+        }
+        ViewModel(StateWithImmutableMap()).addKeyToMap()
+    }
+}

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -534,16 +534,15 @@ class ViewModelSubscriberTest : BaseTest() {
     }
 
     @Test
-    fun testGettingAroundImmutabilityDoesntWork() {
+    fun testNoEventEmittedIfSameStateIsSet() {
         var callCount = 0
         viewModel.subscribe(owner) {
             callCount++
         }
         assertEquals(1, callCount)
-        viewModel.set { copy(list = ArrayList<Int>().apply { add(5) }) }
-        assertEquals(2, callCount)
-        // This is bad. Don't do this. Your subscribers won't get called.
-        viewModel.set { copy(list = (list as ArrayList<Int>).apply { set(0, 3) }) }
-        assertEquals(2, callCount)
+
+        viewModel.set { copy() }
+        assertEquals(1, callCount)
+
     }
 }


### PR DESCRIPTION
Somebody recently was facing buggy behavior in their UI code and asked for help to figure it out. Taking a look at their code their state looked like this

```kotlin
data class FormState(
    val countryInputs: MutableMap<BusinessAccountFormInput, Country?> = HashMap(),
    val textInputs: MutableMap<BusinessAccountFormInput, String?> = HashMap(),
    val dateInputs: MutableMap<BusinessAccountFormInput, AirDate?> = HashMap(),
```

and they were updating it like this
```kotlin
val currentTextInputs = withState(verificationViewModel) { it.textInputs }
currentTextInputs[input] = it
 verificationViewModel.setTextInput(currentTextInputs)
```

This was not working because their state objects were sharing mutable data and weren't actually changing.

Our current debug checks can only validate that types like HashMap are not used, but cannot check for simple MutableMap. This change lets us detect at runtime any mutable state (as long as it causes hashcode changes).
