### PR TITLE
Null sourceObserver in MvRxLifecyclewareObserver onDestroy to fix leak

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference
  * When in a lower lifecycle state, the most recent update will be saved, and delivered when active again.
  */
 internal class MvRxLifecycleAwareObserver<T>(
-    owner: LifecycleOwner,
+    private var owner: LifecycleOwner?,
     private val activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
     private val alwaysDeliverLastValueWhenUnlocked: Boolean = false,
     private var sourceObserver: Observer<T>?) : AtomicReference<Disposable>(), LifecycleObserver, Observer<T>, Disposable {
@@ -37,7 +37,6 @@ internal class MvRxLifecycleAwareObserver<T>(
         onNext: Consumer<T> = Functions.emptyConsumer()
     ) : this(owner, activeState, alwaysDeliverLastValueWhenUnlocked, LambdaObserver<T>(onNext, onError, onComplete, onSubscribe))
 
-    private var owner: LifecycleOwner? = owner
     private var lastUndeliveredValue: T? = null
     private var lastValue: T? = null
     private val locked = AtomicBoolean(true)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
@@ -1,15 +1,20 @@
 package com.airbnb.mvrx
 
-import android.arch.lifecycle.*
+import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.Lifecycle.Event
 import android.arch.lifecycle.Lifecycle.State
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.OnLifecycleEvent
 import io.reactivex.Observer
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.*
+import io.reactivex.functions.Action
+import io.reactivex.functions.Consumer
 import io.reactivex.internal.disposables.DisposableHelper
 import io.reactivex.internal.functions.Functions
 import io.reactivex.internal.observers.LambdaObserver
-import java.util.concurrent.atomic.*
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * An wrapper around an [Observer] associated with a [LifecycleOwner]. It has an [activeState], and when in a lifecycle state greater
@@ -17,19 +22,19 @@ import java.util.concurrent.atomic.*
  * When in a lower lifecycle state, the most recent update will be saved, and delivered when active again.
  */
 internal class MvRxLifecycleAwareObserver<T>(
-        owner: LifecycleOwner,
-        private val activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
-        private val alwaysDeliverLastValueWhenUnlocked: Boolean = false,
-        private val sourceObserver: Observer<T>) : AtomicReference<Disposable>(), LifecycleObserver, Observer<T>, Disposable {
+    owner: LifecycleOwner,
+    private val activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
+    private val alwaysDeliverLastValueWhenUnlocked: Boolean = false,
+    private var sourceObserver: Observer<T>?) : AtomicReference<Disposable>(), LifecycleObserver, Observer<T>, Disposable {
 
     constructor(
-            owner: LifecycleOwner,
-            activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
-            alwaysDeliverLastValueWhenUnlocked: Boolean = false,
-            onComplete: Action = Functions.EMPTY_ACTION,
-            onSubscribe: Consumer<in Disposable> = Functions.emptyConsumer(),
-            onError: Consumer<in Throwable> = Functions.ON_ERROR_MISSING,
-            onNext: Consumer<T> = Functions.emptyConsumer()
+        owner: LifecycleOwner,
+        activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
+        alwaysDeliverLastValueWhenUnlocked: Boolean = false,
+        onComplete: Action = Functions.EMPTY_ACTION,
+        onSubscribe: Consumer<in Disposable> = Functions.emptyConsumer(),
+        onError: Consumer<in Throwable> = Functions.ON_ERROR_MISSING,
+        onNext: Consumer<T> = Functions.emptyConsumer()
     ) : this(owner, activeState, alwaysDeliverLastValueWhenUnlocked, LambdaObserver<T>(onNext, onError, onComplete, onSubscribe))
 
     private var owner: LifecycleOwner? = owner
@@ -40,17 +45,18 @@ internal class MvRxLifecycleAwareObserver<T>(
     override fun onSubscribe(d: Disposable) {
         if (DisposableHelper.setOnce(this, d)) {
             requireOwner().lifecycle.addObserver(this)
-            sourceObserver.onSubscribe(this)
+            requireSourceObserver().onSubscribe(this)
         }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun onDestroy() {
         requireOwner().lifecycle.removeObserver(this)
-        owner = null
         if (!isDisposed) {
             dispose()
         }
+        owner = null
+        sourceObserver = null
     }
 
     @OnLifecycleEvent(Event.ON_ANY)
@@ -68,7 +74,7 @@ internal class MvRxLifecycleAwareObserver<T>(
 
     override fun onNext(t: T) {
         if (!locked.get()) {
-            sourceObserver.onNext(t)
+            requireSourceObserver().onNext(t)
         } else {
             lastUndeliveredValue = t
         }
@@ -78,12 +84,12 @@ internal class MvRxLifecycleAwareObserver<T>(
     override fun onError(e: Throwable) {
         if (!isDisposed) {
             lazySet(DisposableHelper.DISPOSED)
-            sourceObserver.onError(e)
+            requireSourceObserver().onError(e)
         }
     }
 
     override fun onComplete() {
-        sourceObserver.onComplete()
+        requireSourceObserver().onComplete()
     }
 
     override fun dispose() {
@@ -111,9 +117,11 @@ internal class MvRxLifecycleAwareObserver<T>(
         locked.set(true)
     }
 
-    private fun requireOwner(): LifecycleOwner {
-        return owner!!
-    }
+    private fun requireOwner(): LifecycleOwner = requireNotNull(owner) { "Cannot access lifecycleOwner after onDestroy." }
+
+
+    private fun requireSourceObserver() = requireNotNull(sourceObserver) { "Cannot access observer after onDestroy." }
+
 
     companion object {
 


### PR DESCRIPTION
We maintain a collection of disposables in a viewmodel which are disposed onClear:
```
  /**
     * Override this to provide the initial state.
     */
    @CallSuper
    override fun onCleared() {
        super.onCleared()
        disposables.dispose()
    }
```

However, `MvRxLifecycleAwareObserver` maintains a reference to a source observer (often fragment). While we dispose that subscription in `onDestroy` of the fragment, the `CompositeObservable` in `BaseMvRxViewModel` retains a reference to it, leaking the fragment until `onClear` is called for the ViewModel. If you rotate your phone a bunch, you will have many fragments referenced via this chain before `onClear` is called.