### PR TITLE
Don't re-emit state value stop->start if the state did not change

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -331,7 +331,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
 
         val lifecycleAwareObserver = MvRxLifecycleAwareObserver(
             lifecycleOwner,
-            alwaysDeliverLastValueWhenUnlocked = true,
             onNext = Consumer<T> { subscriber(it) }
         )
         return observeOn(AndroidSchedulers.mainThread())

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -36,55 +36,84 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
 
     /**
      * Subscribes to all state updates for the given viewModel.
+     *
+     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
+     * or logging. Default: false.
      */
-    fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(subscriber: (S) -> Unit) = subscribe(this@MvRxView, subscriber)
+    fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(uniqueOnly: Boolean = false, subscriber: (S) -> Unit) = subscribe(this@MvRxView, uniqueOnly, subscriber)
 
     /**
      * Subscribes to state changes for only a specific property and calls the subscribe with
      * only that single property.
+     *
+     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
+     * or logging. Default: false.
      */
     fun <S : MvRxState, A> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
+        uniqueOnly: Boolean = false,
         subscriber: (A) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, uniqueOnly, subscriber)
 
     /**
      * Subscribe to changes in an async property. There are optional parameters for onSuccess
      * and onFail which automatically unwrap the value or error.
+     *
+     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
+     * or logging. Default: false.
      */
     fun <S : MvRxState, T> BaseMvRxViewModel<S>.asyncSubscribe(
         asyncProp: KProperty1<S, Async<T>>,
+        uniqueOnly: Boolean = false,
         onFail: ((Throwable) -> Unit)? = null,
         onSuccess: ((T) -> Unit)? = null
-    ) = asyncSubscribe(this@MvRxView, asyncProp, onFail, onSuccess)
+    ) = asyncSubscribe(this@MvRxView, asyncProp, uniqueOnly, onFail, onSuccess)
 
     /**
      * Subscribes to state changes for two properties.
+     *
+     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
+     * or logging. Default: false.
      */
     fun <S : MvRxState, A, B> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
+        uniqueOnly: Boolean = false,
         subscriber: (A, B) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, prop2, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, uniqueOnly, subscriber)
 
     /**
      * Subscribes to state changes for three properties.
+     *
+     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
+     * or logging. Default: false.
      */
     fun <S : MvRxState, A, B, C> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
+        uniqueOnly: Boolean = false,
         subscriber: (A, B, C) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, uniqueOnly, subscriber)
 
     /**
      * Subscribes to state changes for four properties.
+     *
+     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
+     * or logging. Default: false.
      */
     fun <S : MvRxState, A, B, C, D> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
         prop4: KProperty1<S, D>,
+        uniqueOnly: Boolean = false,
         subscriber: (A, B, C, D) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, uniqueOnly, subscriber)
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -38,8 +38,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * Subscribes to all state updates for the given viewModel.
      *
      * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
-     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
-     * or logging. Default: false.
+     * will only be emitted if the state changed. This is useful for transient views that should only
+     * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
+     * and recreated the previous state is necessary to recreate the view.
+     *
+     * Default: false.
      */
     fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(uniqueOnly: Boolean = false, subscriber: (S) -> Unit) = subscribe(this@MvRxView, uniqueOnly, subscriber)
 
@@ -48,8 +51,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * only that single property.
      *
      * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
-     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
-     * or logging. Default: false.
+     * will only be emitted if the state changed. This is useful for transient views that should only
+     * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
+     * and recreated the previous state is necessary to recreate the view.
+     *
+     * Default: false.
      */
     fun <S : MvRxState, A> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
@@ -62,8 +68,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * and onFail which automatically unwrap the value or error.
      *
      * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
-     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
-     * or logging. Default: false.
+     * will only be emitted if the state changed. This is useful for transient views that should only
+     * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
+     * and recreated the previous state is necessary to recreate the view.
+     *
+     * Default: false.
      */
     fun <S : MvRxState, T> BaseMvRxViewModel<S>.asyncSubscribe(
         asyncProp: KProperty1<S, Async<T>>,
@@ -76,8 +85,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * Subscribes to state changes for two properties.
      *
      * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
-     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
-     * or logging. Default: false.
+     * will only be emitted if the state changed. This is useful for transient views that should only
+     * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
+     * and recreated the previous state is necessary to recreate the view.
+     *
+     * Default: false.
      */
     fun <S : MvRxState, A, B> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
@@ -90,8 +102,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * Subscribes to state changes for three properties.
      *
      * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
-     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
-     * or logging. Default: false.
+     * will only be emitted if the state changed. This is useful for transient views that should only
+     * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
+     * and recreated the previous state is necessary to recreate the view.
+     *
+     * Default: false.
      */
     fun <S : MvRxState, A, B, C> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
@@ -105,8 +120,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      * Subscribes to state changes for four properties.
      *
      * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
-     * will only be emitted if the state changed. This is useful for transient views that should only be shown once,
-     * or logging. Default: false.
+     * will only be emitted if the state changed. This is useful for transient views that should only
+     * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
+     * and recreated the previous state is necessary to recreate the view.
+     *
+     * Default: false.
      */
     fun <S : MvRxState, A, B, C, D> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -476,11 +476,27 @@ class ViewModelSubscriberTest : BaseTest() {
     }
 
     @Test
-    fun testSubscribeCalledOnStartIfUpdateOccurredInStop() {
+    fun testSubscribeCalledOnRestart() {
+        owner.lifecycle.markState(Lifecycle.State.RESUMED)
+        var callCount = 0
+        viewModel.subscribe(owner) {
+            callCount++
+        }
+        assertEquals(1, callCount)
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertEquals(1, callCount)
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertEquals(1, callCount)
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        assertEquals(2, callCount)
+    }
+
+    @Test
+    fun testUniqueOnlySubscribeCalledOnStartIfUpdateOccurredInStop() {
         owner.lifecycle.markState(Lifecycle.State.STARTED)
 
         var callCount = 0
-        viewModel.subscribe(owner) {
+        viewModel.subscribe(owner, uniqueOnly = true) {
             callCount++
         }
 
@@ -498,7 +514,7 @@ class ViewModelSubscriberTest : BaseTest() {
         owner.lifecycle.markState(Lifecycle.State.STARTED)
 
         var callCount = 0
-        viewModel.subscribe(owner) {
+        viewModel.subscribe(owner, uniqueOnly = true) {
             callCount++
         }
 

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -475,6 +475,39 @@ class ViewModelSubscriberTest : BaseTest() {
         assertEquals(3, callCount)
     }
 
+    @Test
+    fun testSubscribeCalledOnStartIfUpdateOccurredInStop() {
+        owner.lifecycle.markState(Lifecycle.State.STARTED)
+
+        var callCount = 0
+        viewModel.subscribe(owner) {
+            callCount++
+        }
+
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+        viewModel.setFoo(1)
+        assertEquals(1, callCount)
+
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        assertEquals(2, callCount)
+    }
+
+    @Test
+    fun testSubscribeNotCalledOnStartIfNoUpdateOccurredInStop() {
+        owner.lifecycle.markState(Lifecycle.State.STARTED)
+
+        var callCount = 0
+        viewModel.subscribe(owner) {
+            callCount++
+        }
+
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertEquals(1, callCount)
+
+        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        assertEquals(1, callCount)
+    }
 
     @Test
     fun testAsync() {

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -527,23 +527,6 @@ class ViewModelSubscriberTest : BaseTest() {
     }
 
     @Test
-    fun testSubscribeCalledOnRestart() {
-        owner.lifecycle.markState(Lifecycle.State.RESUMED)
-
-        var callCount = 0
-        viewModel.subscribe(owner) {
-            callCount++
-        }
-        assertEquals(1, callCount)
-        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-        assertEquals(1, callCount)
-        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-        assertEquals(1, callCount)
-        owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
-        assertEquals(2, callCount)
-    }
-
-    @Test
     fun testAddToList() {
         var callCount = 0
         viewModel.subscribe(owner) {

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewSubscriberTest.kt
@@ -15,20 +15,36 @@ class ViewSubscriberFragment : BaseMvRxFragment() {
     private val viewModel: ViewSubscriberViewModel by fragmentViewModel()
 
     var subscribeCallCount = 0
-    var selectSubscribeCalled = -1
+    var subscribeUniqueOnlyCallCount = 0
+
+    var selectSubscribeValue = -1
+    var selectSubscribeCallCount = 0
+
+    var selectSubscribeUniqueOnlyValue = -1
+    var selectSubscribeUniqueOnlyCallCount = 0
+
     var invalidateCallCount = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.subscribe { _ -> subscribeCallCount++ }
+        viewModel.subscribe(uniqueOnly = true) { _ -> subscribeUniqueOnlyCallCount++ }
+
         viewModel.selectSubscribe(ViewSubscriberState::foo) {
-            selectSubscribeCalled = it
+            selectSubscribeValue = it
+            selectSubscribeCallCount++
+        }
+        viewModel.selectSubscribe(ViewSubscriberState::foo, uniqueOnly = true) {
+            selectSubscribeUniqueOnlyValue = it
+            selectSubscribeUniqueOnlyCallCount++
         }
     }
 
     fun setFoo(foo: Int) = viewModel.setFoo(foo)
 
-    override fun invalidate() { invalidateCallCount ++ }
+    override fun invalidate() {
+        invalidateCallCount++
+    }
 }
 
 class ViewSubscriberTest : BaseTest() {
@@ -43,14 +59,36 @@ class ViewSubscriberTest : BaseTest() {
     }
 
     @Test
+    fun testSubscribeUniqueOnly() {
+        val (_, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+        fragment.setFoo(0)
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+        fragment.setFoo(1)
+        assertEquals(2, fragment.subscribeUniqueOnlyCallCount)
+    }
+
+    @Test
     fun testSelectSubscribe() {
         val (_, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
-        assertEquals(0, fragment.selectSubscribeCalled)
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
         fragment.setFoo(0)
-        assertEquals(0, fragment.selectSubscribeCalled)
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
         fragment.setFoo(1)
-        assertEquals(1, fragment.selectSubscribeCalled)
-        assertEquals(1, fragment.selectSubscribeCalled)
+        assertEquals(1, fragment.selectSubscribeValue)
+        assertEquals(1, fragment.selectSubscribeUniqueOnlyValue)
+    }
+
+    @Test
+    fun testSelectSubscribeUniqueOnly() {
+        val (_, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+        fragment.setFoo(0)
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+        fragment.setFoo(1)
+        assertEquals(1, fragment.selectSubscribeUniqueOnlyValue)
     }
 
     @Test
@@ -60,16 +98,106 @@ class ViewSubscriberTest : BaseTest() {
     }
 
     @Test
+    fun selectSubscribeFromStopToStartWhenStateChanged() {
+        val (controller, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+
+        controller.pause()
+        controller.stop()
+
+        fragment.setFoo(1)
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+
+        controller.start()
+        controller.resume()
+
+        assertEquals(1, fragment.selectSubscribeValue)
+        assertEquals(1, fragment.selectSubscribeUniqueOnlyValue)
+    }
+
+    @Test
+    fun selectSubscribeFromStopToStartWhenStateNotChanged() {
+        val (controller, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(1, fragment.selectSubscribeCallCount)
+
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+        assertEquals(1, fragment.selectSubscribeUniqueOnlyCallCount)
+
+        controller.pause()
+        controller.stop()
+
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(1, fragment.selectSubscribeCallCount)
+
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+        assertEquals(1, fragment.selectSubscribeUniqueOnlyCallCount)
+
+        controller.start()
+        controller.resume()
+
+        // If unique is not set to true, we always receive an update when unlocked.
+        assertEquals(0, fragment.selectSubscribeValue)
+        assertEquals(2, fragment.selectSubscribeCallCount)
+
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+        assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
+    }
+
+    @Test
+    fun subscribeFromStopToStartWhenStateChanged() {
+        val (controller, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
+        assertEquals(1, fragment.subscribeCallCount)
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+
+        controller.pause()
+        controller.stop()
+
+        fragment.setFoo(1)
+        assertEquals(1, fragment.subscribeCallCount)
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+
+        controller.start()
+        controller.resume()
+
+        assertEquals(2, fragment.subscribeCallCount)
+        assertEquals(2, fragment.subscribeUniqueOnlyCallCount)
+    }
+
+    @Test
+    fun subscribeFromStopToStartWhenStateNotChanged() {
+        val (controller, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
+        assertEquals(1, fragment.subscribeCallCount)
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+
+        controller.pause()
+        controller.stop()
+
+        assertEquals(1, fragment.subscribeCallCount)
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+
+        controller.start()
+        controller.resume()
+
+        assertEquals(2, fragment.subscribeCallCount)
+        assertEquals(1, fragment.subscribeUniqueOnlyCallCount)
+    }
+
+    @Test
     fun invalidateCalledFromStopToStartWhenStateChanged() {
         val (controller, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
         assertEquals(1, fragment.invalidateCallCount)
 
+        controller.pause()
         controller.stop()
 
         fragment.setFoo(1)
         assertEquals(1, fragment.invalidateCallCount)
 
         controller.start()
+        controller.resume()
 
         assertEquals(2, fragment.invalidateCallCount)
     }
@@ -79,9 +207,13 @@ class ViewSubscriberTest : BaseTest() {
         val (controller, fragment) = createFragment<ViewSubscriberFragment, TestActivity>()
         assertEquals(1, fragment.invalidateCallCount)
 
+        controller.pause()
         controller.stop()
 
+        assertEquals(1, fragment.invalidateCallCount)
+
         controller.start()
+        controller.resume()
 
         assertEquals(2, fragment.invalidateCallCount)
     }


### PR DESCRIPTION
As brought up in https://github.com/airbnb/MvRx/issues/94 there seems to be no need to remit the state value during state transitions of `stopped` -> `started` unless the value changed.

We will alway call `invalidate` on any call to `started`.

Closes https://github.com/airbnb/MvRx/issues/94