### PR TITLE
Add default proguard config for sample app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.41'
+    ext.kotlinVersion = '1.2.51'
     ext.supportLibVersion = '27.1.1'
     ext.lifecycleVersion = '1.1.1'
     ext.robolectricVersion = '3.8'
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -12,11 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 27
-    }
-    buildTypes {
-        release {
-            consumerProguardFiles 'proguard-rules.pro'
-        }
+        consumerProguardFiles 'proguard-rules.pro'
     }
     lintOptions {
         abortOnError true

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,7 +14,14 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
+        }
+    }
 }
 
 androidExtensions {

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -5,6 +5,13 @@
 # Print out the full proguard config used for every build
 -printconfiguration build/outputs/fullProguardConfig.pro
 
+
+#
+# Keep rules that are used because MvRx uses Kotlin and Kotlin reflection. These are not defined in the lib
+# as they are not specific to the lib itself but need to be most likley present in any project that uses Kotlin 
+# and Kotlin reflection.
+#
+
 # These classes are used via kotlin reflection and the keep might not be required anymore once Progurad supports
 # Kotlin reflection directlty.
 -keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
@@ -27,14 +34,6 @@
 # https://stackoverflow.com/questions/33547643/how-to-use-kotlin-with-proguard
 -dontwarn kotlin.**
 
-# https://app.bugsnag.com/airbnb/android-1/errors/59f6c07487a5c5001a49d882?filters[event.since][0]=all&filters[event.severity][0][value]=error&filters[event.severity][0][type]=eq
-# https://github.com/square/okhttp/issues/3582
--keep class okhttp3.internal.publicsuffix.PublicSuffixDatabase
-
-# The code is safeguarded against API28 use so we can just ignore the warning bout Handler.createAsync(looper) not existing.
-# Can be removed when compiled against API >=28
--dontwarn com.airbnb.epoxy.EpoxyAsyncUtil
-
 # RxJava
 -keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
    long producerIndex;
@@ -43,6 +42,14 @@
 
 # Oddly need to keep that even though Evernote state is not used in the app.
 -keepnames class * { @com.evernote.android.state.State *;}
+
+#
+# Keep rules that are unique to the sample project because it uses epoxy, okhttp3, moshi and retrofit.
+#
+
+# The code is safeguarded against API28 use so we can just ignore the warning bout Handler.createAsync(looper) not existing.
+# Can be removed when compiled against API >=28
+-dontwarn com.airbnb.epoxy.EpoxyAsyncUtil
 
 #
 # From: https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -70,7 +77,6 @@
 -dontwarn retrofit2.-KotlinExtensions
 
 
-
 #
 # From https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
 #
@@ -86,7 +92,6 @@
 
 # OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontwarn okhttp3.internal.platform.ConscryptPlatform
-
 
 
 #
@@ -145,7 +150,6 @@
 #}
 
 
-
 # 
 # From: https://github.com/square/moshi/blob/master/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
 #
@@ -155,4 +159,3 @@
 -keepclassmembers class kotlin.Metadata {
     public <methods>;
 }
-

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -7,9 +7,9 @@
 
 
 #
-# Keep rules that are used because MvRx uses Kotlin and Kotlin reflection. These are not defined in the lib
-# as they are not specific to the lib itself but need to be most likley present in any project that uses Kotlin 
-# and Kotlin reflection.
+# Keep rules that are used because MvRx uses Kotlin, Kotlin reflection and RxJava. These are not defined in the 
+# lib as they are not specific to the lib itself but need to be most likley present in any project that uses 
+# Kotlin, Kotlin reflection and RxJava.
 #
 
 # These classes are used via kotlin reflection and the keep might not be required anymore once Progurad supports

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -41,11 +41,6 @@
    long consumerIndex;
 }
 
-# Keep the models, this can be done in a better way but for this sample we just keep all the models
--keep class com.airbnb.mvrx.sample.models.** {
-  *;
-}
-
 # Oddly need to keep that even though Evernote state is not used in the app.
 -keepnames class * { @com.evernote.android.state.State *;}
 

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -1,0 +1,163 @@
+# This file contains project specific proguard rules
+
+-android
+
+# Print out the full proguard config used for every build
+-printconfiguration build/outputs/fullProguardConfig.pro
+
+# These classes are used via kotlin reflection and the keep might not be required anymore once Progurad supports
+# Kotlin reflection directlty.
+-keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+-keep class kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition
+-keep class kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition
+-keep class kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition
+
+# If Companion objects are instantiated via Kotlin reflection and they extend/implement a class that Proguard
+# would have removed or inlined we run into trouble as the inheritance is still in the Metadata annoation 
+# read by Kotlin reflection.
+# FIXME Remove if Kotlin reflection is supported by Pro/Dexguard
+-if class **$Companion extends **
+-keep class <2>
+-if class **$Companion implements **
+-keep class <2>
+
+# https://medium.com/@AthorNZ/kotlin-metadata-jackson-and-proguard-f64f51e5ed32
+-keep class kotlin.Metadata { *; }
+
+# https://stackoverflow.com/questions/33547643/how-to-use-kotlin-with-proguard
+-dontwarn kotlin.**
+
+# https://app.bugsnag.com/airbnb/android-1/errors/59f6c07487a5c5001a49d882?filters[event.since][0]=all&filters[event.severity][0][value]=error&filters[event.severity][0][type]=eq
+# https://github.com/square/okhttp/issues/3582
+-keep class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# The code is safeguarded against API28 use so we can just ignore the warning bout Handler.createAsync(looper) not existing.
+# Can be removed when compiled against API >=28
+-dontwarn com.airbnb.epoxy.EpoxyAsyncUtil
+
+# RxJava
+-keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
+   long producerIndex;
+   long consumerIndex;
+}
+
+# Keep the models, this can be done in a better way but for this sample we just keep all the models
+-keep class com.airbnb.mvrx.sample.models.** {
+  *;
+}
+
+# Oddly need to keep that even though Evernote state is not used in the app.
+-keepnames class * { @com.evernote.android.state.State *;}
+
+#
+# From: https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+#
+
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.-KotlinExtensions
+
+
+
+#
+# From https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+#
+
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
+
+
+
+#
+# From: https://github.com/square/moshi/blob/master/moshi/src/main/resources/META-INF/proguard/moshi.pro
+#
+
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+-keepclasseswithmembers class * {
+    @com.squareup.moshi.* <methods>;
+}
+
+-keep @com.squareup.moshi.JsonQualifier interface *
+
+# Enum field names are used by the integrated EnumJsonAdapter.
+# Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
+-keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
+    <fields>;
+}
+
+# The name of @JsonClass types is used to look up the generated adapter.
+-keepnames @com.squareup.moshi.JsonClass class *
+
+# Retain generated JsonAdapters if annotated type is retained.
+-if @com.squareup.moshi.JsonClass class *
+-keep class <1>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*
+-keep class <1>_<2>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+# Proguard bug: https://sourceforge.net/p/proguard/bugs/731/
+#-if @com.squareup.moshi.JsonClass class **$*$*
+#-keep class <1>_<2>_<3>JsonAdapter {
+#    <init>(...);
+#    <fields>;
+#}
+#-if @com.squareup.moshi.JsonClass class **$*$*$*
+#-keep class <1>_<2>_<3>_<4>JsonAdapter {
+#    <init>(...);
+#    <fields>;
+#}
+#-if @com.squareup.moshi.JsonClass class **$*$*$*$*
+#-keep class <1>_<2>_<3>_<4>_<5>JsonAdapter {
+#    <init>(...);
+#    <fields>;
+#}
+#-if @com.squareup.moshi.JsonClass class **$*$*$*$*$*
+#-keep class <1>_<2>_<3>_<4>_<5>_<6>JsonAdapter {
+#    <init>(...);
+#    <fields>;
+#}
+
+
+
+# 
+# From: https://github.com/square/moshi/blob/master/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
+#
+
+-keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}
+

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -8,19 +8,19 @@
 
 #
 # Keep rules that are used because MvRx uses Kotlin, Kotlin reflection and RxJava. These are not defined in the 
-# lib as they are not specific to the lib itself but need to be most likley present in any project that uses 
+# lib as they are not specific to the lib itself but need to be most likely present in any project that uses 
 # Kotlin, Kotlin reflection and RxJava.
 #
 
-# These classes are used via kotlin reflection and the keep might not be required anymore once Progurad supports
-# Kotlin reflection directlty.
+# These classes are used via kotlin reflection and the keep might not be required anymore once Proguard supports
+# Kotlin reflection directly.
 -keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
 -keep class kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition
 -keep class kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition
 -keep class kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition
 
 # If Companion objects are instantiated via Kotlin reflection and they extend/implement a class that Proguard
-# would have removed or inlined we run into trouble as the inheritance is still in the Metadata annoation 
+# would have removed or inlined we run into trouble as the inheritance is still in the Metadata annotation 
 # read by Kotlin reflection.
 # FIXME Remove if Kotlin reflection is supported by Pro/Dexguard
 -if class **$Companion extends **

--- a/sample/src/main/java/com/airbnb/mvrx/sample/models/Joke.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/models/Joke.kt
@@ -3,6 +3,6 @@ package com.airbnb.mvrx.sample.models
 import com.squareup.moshi.Json
 
 data class Joke(
-        @Json(name = "id") val id: String,
-        @Json(name = "joke") val joke: String
+        @get:Json(name = "id") @Json(name = "id") val id: String,
+        @get:Json(name = "joke") @Json(name = "joke") val joke: String
 )

--- a/sample/src/main/java/com/airbnb/mvrx/sample/models/JokesResponse.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/models/JokesResponse.kt
@@ -3,6 +3,6 @@ package com.airbnb.mvrx.sample.models
 import com.squareup.moshi.Json
 
 data class JokesResponse(
-        @Json(name = "next_page") val nextPage: Int,
-        @Json(name = "results") val results: List<Joke>
+        @get:Json(name = "next_page") @Json(name = "next_page") val nextPage: Int,
+        @get:Json(name = "results") @Json(name = "results") val results: List<Joke>
 )

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -14,7 +14,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     android {
         sourceSets {


### PR DESCRIPTION
Update AGP to 3.2.0
Update Kotlin to 1.2.51
Include consumer proguard file in every variant
Add default proguard config for sample app
Run Proguard on release build type for sample app

Fixes: https://github.com/airbnb/MvRx/issues/126