### PR TITLE
Allow for Fragment ViewModel factory (#69)

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelFactory.kt
@@ -1,5 +1,6 @@
 package com.airbnb.mvrx
 
+import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentActivity
 
 /**
@@ -9,8 +10,20 @@ import android.support.v4.app.FragmentActivity
 interface MvRxViewModelFactory<S : MvRxState> {
     /**
      * This will be called when your ViewModel needs to created. This *needs* to be annotated with [JvmStatic].
-     * @param state: The initial state for your ViewModel. This will be populated from fragment / activity args
-     * and persisted state.
+     * @param state: The initial state for your ViewModel. This will be populated from activity persisted state.
      */
     fun create(activity: FragmentActivity, state: S): BaseMvRxViewModel<S>
+}
+
+/**
+ * Implement this in the companion object of a MvRxViewModel if your ViewModel needs more dependencies than just initial state.
+ * If you only need the [FragmentActivity] then you can use the [MvRxViewModelFactory].
+ * If all you need is initial state, you don't need to implement this at all.
+ */
+interface MvRxFragmentViewModelFactory<S : MvRxState> {
+    /**
+     * This will be called when your ViewModel needs to created. This *needs* to be annotated with [JvmStatic].
+     * @param state: The initial state for your ViewModel. This will be populated from fragment args and persisted state.
+     */
+    fun create(fragment: Fragment, state: S): BaseMvRxViewModel<S>
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
@@ -89,7 +89,7 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
         restoreViewModels(fragment, map, savedInstanceState, ownerArgs)
     }
 
-    private inline fun <reified H> restoreViewModels(host: H, map: MutableMap<String, ViewModel>, savedInstanceState: Bundle?, ownerArgs: Any? = null) {
+    private fun <H> restoreViewModels(host: H, map: MutableMap<String, ViewModel>, savedInstanceState: Bundle?, ownerArgs: Any? = null) {
         savedInstanceState ?: return
         val viewModelsState = savedInstanceState.getBundle(KEY_MVRX_SAVED_INSTANCE_STATE)
             ?: throw IllegalStateException("You are trying to call restoreViewModels but you never called saveViewModels!")
@@ -103,11 +103,9 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
             } else {
                 ownerArgs
             }
-            if (H::class is Fragment) {
-                map[it] = restoreViewModel(host as Fragment, viewModelsState.getParcelable(it), arguments)
-            } else {
-                map[it] = restoreViewModel(host as FragmentActivity, viewModelsState.getParcelable(it), arguments)
-            }
+            map[it] = (host as? Fragment)
+                    ?.let { fragment -> restoreViewModel(fragment, viewModelsState.getParcelable(it), arguments) }
+                    ?: restoreViewModel(host as FragmentActivity, viewModelsState.getParcelable(it), arguments)
         }
     }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
@@ -1,3 +1,4 @@
+
 package com.airbnb.mvrx
 
 import android.arch.lifecycle.ViewModel
@@ -77,12 +78,21 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
     fun restoreViewModels(fragment: Fragment, savedInstanceState: Bundle?) {
         savedInstanceState ?: return
         val args = fragment.arguments?.get(MvRx.KEY_ARG)
-        restoreViewModels(map, fragment.requireActivity(), savedInstanceState, args)
+        restoreViewModels(map, fragment, savedInstanceState, args)
     }
 
     internal fun restoreViewModels(map: MutableMap<String, ViewModel>, activity: FragmentActivity, savedInstanceState: Bundle?, ownerArgs: Any? = null) {
+        restoreViewModels(activity, map, savedInstanceState, ownerArgs)
+    }
+
+    internal fun restoreViewModels(map: MutableMap<String, ViewModel>, fragment: Fragment, savedInstanceState: Bundle?, ownerArgs: Any? = null) {
+        restoreViewModels(fragment, map, savedInstanceState, ownerArgs)
+    }
+
+    private inline fun <reified H> restoreViewModels(host: H, map: MutableMap<String, ViewModel>, savedInstanceState: Bundle?, ownerArgs: Any? = null) {
         savedInstanceState ?: return
-        val viewModelsState = savedInstanceState.getBundle(KEY_MVRX_SAVED_INSTANCE_STATE) ?: throw IllegalStateException("You are trying to call restoreViewModels but you never called saveViewModels!")
+        val viewModelsState = savedInstanceState.getBundle(KEY_MVRX_SAVED_INSTANCE_STATE)
+            ?: throw IllegalStateException("You are trying to call restoreViewModels but you never called saveViewModels!")
         restoreFragmentArgsFromSavedInstanceState(savedInstanceState)
         if (map.isNotEmpty()) return
         viewModelsState.keySet()?.forEach {
@@ -93,7 +103,11 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
             } else {
                 ownerArgs
             }
-            map[it] = restoreViewModel(activity, viewModelsState.getParcelable(it), arguments)
+            if (H::class is Fragment) {
+                map[it] = restoreViewModel(host as Fragment, viewModelsState.getParcelable(it), arguments)
+            } else {
+                map[it] = restoreViewModel(host as FragmentActivity, viewModelsState.getParcelable(it), arguments)
+            }
         }
     }
 
@@ -110,6 +124,14 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
         // the Fragment args that the ViewModel was created with.
         val state = _initialStateProvider(stateClass, arguments).let(viewModelState::restorePersistedState)
         return createViewModel(viewModelClass, activity, state)
+    }
+
+    private fun restoreViewModel(fragment: Fragment, holder: MvRxPersistedViewModelHolder, arguments: Any?): ViewModel {
+        val (viewModelClass, stateClass, viewModelState) = holder
+        // If there is a key in the fragmentArgsForActivityViewModelState map, then this is an activity ViewModel. The map value will contain
+        // the Fragment args that the ViewModel was created with.
+        val state = _initialStateProvider(stateClass, arguments).let(viewModelState::restorePersistedState)
+        return createViewModel(viewModelClass, fragment, state)
     }
 
     /**


### PR DESCRIPTION
Injecting with Dagger #69 is very hard without the Fragment been passed for Fragment `ViewModels`. So, I added a `MvRxFragmentViewModelFactory` as another factory type. To keep backward compatibility if the `Fragment` factory can't be found we can fall back to the `Activity` factory. If no factory can be found then like before try the single state arg `ViewModel` constructor before crashing as it would before.