### PR TITLE
Upgrade to support lib 28.0.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
   - platform-tools
   - build-tools-28.0.2
   - build-tools-28.0.3
-  - android-27
+  - android-28
   - extra-google-google_play_services
   - extra-android-m2repository
   - extra-android-support

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.moshiVersion = '1.6.0'
     ext.koinVersion = '0.9.3'
     ext.retrofitVersion = '2.4.0'
-    ext.navVersion = '1.0.0-alpha04'
+    ext.navVersion = '1.0.0-alpha08'
     ext.roomVersion = '1.1.1'
     ext.buildToolsVersion = '28.0.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext.kotlinVersion = '1.2.51'
-    ext.supportLibVersion = '27.1.1'
+    ext.supportLibVersion = '28.0.0'
     ext.lifecycleVersion = '1.1.1'
-    ext.robolectricVersion = '3.8'
+    ext.robolectricVersion = '4.0.2'
     ext.epoxyVersion = '2.16.4'
     ext.moshiVersion = '1.6.0'
     ext.koinVersion = '0.9.3'
@@ -16,7 +16,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -6,12 +6,12 @@ apply from: 'gradle-maven-push.gradle'
 apply plugin: "jacoco"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     resourcePrefix 'mvrx_'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         consumerProguardFiles 'proguard-rules.pro'
     }
     buildToolsVersion "$buildToolsVersion"

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
@@ -83,8 +83,8 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
     internal fun restoreViewModels(map: MutableMap<String, ViewModel>, activity: FragmentActivity, savedInstanceState: Bundle?, ownerArgs: Any? = null) {
         savedInstanceState ?: return
         val viewModelsState = savedInstanceState.getBundle(KEY_MVRX_SAVED_INSTANCE_STATE) ?: throw IllegalStateException("You are trying to call restoreViewModels but you never called saveViewModels!")
-        if (map.isNotEmpty()) return
         restoreFragmentArgsFromSavedInstanceState(savedInstanceState)
+        if (map.isNotEmpty()) return
         viewModelsState.keySet()?.forEach {
             // In the case that we are restoring an Activity ViewModel created by a Fragment, `ownerArgs` will be those of the Activity. So we
             // need to use the persisted Fragment args instead.

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseTest.kt
@@ -58,12 +58,12 @@ abstract class BaseTest {
             args: Parcelable? = null
     ): Pair<ActivityController<A>, F> {
         val controller = Robolectric.buildActivity(A::class.java)
-                .create(savedInstanceState)
-                .start()
-                .resume()
-                .visible()
+        if (savedInstanceState == null) {
+            controller.setup()
+        } else {
+            controller.setup(savedInstanceState)
+        }
         val activity = controller.get()
-
         val fragment = if (savedInstanceState == null) {
             F::class.java.newInstance().apply {
                 arguments = Bundle().apply { putParcelable(MvRx.KEY_ARG, args) }
@@ -72,7 +72,10 @@ abstract class BaseTest {
         } else {
             activity.supportFragmentManager.findFragmentByTag("TAG") as F
         }
-
         return controller to fragment
+    }
+
+    protected inline fun <reified F : Fragment> ActivityController<out AppCompatActivity>.mvRxFragment() : F {
+        return get().supportFragmentManager.findFragmentByTag("TAG") as F
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.airbnb.sample"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation("com.android.support:appcompat-v7:$supportLibVersion") { exclude group: 'android.arch.lifecycle' }
     implementation("com.android.support:recyclerview-v7:$supportLibVersion") { exclude group: 'android.arch.lifecycle' }
     implementation "android.arch.lifecycle:extensions:$lifecycleVersion"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation("com.airbnb.android:epoxy:$epoxyVersion") { exclude group: 'com.android.support' }
     kapt "com.airbnb.android:epoxy-processor:$epoxyVersion"
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.airbnb.mvrx.todoapp"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
 

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation "android.arch.persistence.room:runtime:$roomVersion"
     implementation "android.arch.persistence.room:rxjava2:$roomVersion"
     kapt "android.arch.persistence.room:compiler:$roomVersion"
-    implementation 'com.android.support.test.espresso:espresso-idling-resource:2.2.2'
+    implementation 'com.android.support.test.espresso:espresso-idling-resource:3.0.2'
     debugImplementation 'com.amitshekhar.android:debug-db:1.0.4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha4'

--- a/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/MainActivity.kt
+++ b/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/MainActivity.kt
@@ -26,22 +26,22 @@ class MainActivity : BaseMvRxActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val navView: NavigationView = findViewById(R.id.nav_view)
+        val navView = findViewById<NavigationView>(R.id.nav_view)
         val toolbar: Toolbar = findViewById(R.id.toolbar)
 
         setSupportActionBar(toolbar)
         navView.setupWithNavController(navController)
         setupActionBarWithNavController(navController)
 
-        navController.addOnNavigatedListener { _, destination ->
+        navController.addOnDestinationChangedListener { _, destination, _ ->
             val isDrawer = destination.isDrawerDestination()
             toolbar.setNavigationIcon(if (isDrawer) R.drawable.ic_menu else R.drawable.ic_back)
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?) = when(item?.itemId ?: 0) {
+    override fun onOptionsItemSelected(item: MenuItem?) = when (item?.itemId ?: 0) {
         android.R.id.home -> {
-            if (navController.currentDestination.isDrawerDestination()) {
+            if (navController.currentDestination?.isDrawerDestination() == true) {
                 drawerLayout.openDrawer(GravityCompat.START)
             } else {
                 navController.navigateUp()

--- a/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/StatisticsFragment.kt
+++ b/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/StatisticsFragment.kt
@@ -11,7 +11,7 @@ class StatisticsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fab.visibility = View.GONE
+        fab.hide()
     }
 
     override fun epoxyController() = simpleController(viewModel) { state ->


### PR DESCRIPTION
This PR bumps MvRx to 28 sdk and support libs. It includes a necessary internal change of always restoring `fragmentArgsForActivityViewModelState` map during `restoreViewModels`.

When a fragment viewModel is scoped to an activity, we store the fragment args in the savedInstanceState of the activity. This is to make it accessible during the restoration process.

To repro crash:
- use an `activityViewModel` in a fragment
- cause a configuration change (rotate phone)
- Background app, make sure process is killed
- restart app.

During the configuration change `fragmentArgsForActivityViewModelState` was never fully restored, because the viewModelMap was empty. Therefore, in `onSaveInstanceState` during the process death, the args are lost, causing a crash when the app restarts.

This PR, moves the restoration before the early terminate in `restoreViewModels`.

@gpeal @elihart 