### PR TITLE
Avoid unnecessary comparison for multiple downstream subscription in state store

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/RealMvRxStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/RealMvRxStateStore.kt
@@ -33,7 +33,9 @@ class RealMvRxStateStore<S : Any>(initialState: S) : MvRxStateStore<S> {
 
     private val jobs = Jobs<S>()
 
-    override val observable: Observable<S> = subject.distinctUntilChanged()
+    // We have already checked distinct before calling `subject.onNext`
+    // This avoids unnecessary comparison for each downstream subscription
+    override val observable: Observable<S> = subject
     /**
      * This is automatically updated from a subscription on the subject for easy access to the
      * current state.
@@ -132,7 +134,7 @@ class RealMvRxStateStore<S : Any>(initialState: S) : MvRxStateStore<S> {
 
         blocks
                 .fold(state) { state, reducer -> state.reducer() }
-                .run { subject.onNext(this) }
+                .run { if (this != state) subject.onNext(this) }
     }
 
     private fun handleError(throwable: Throwable) {


### PR DESCRIPTION
`subject.distinctUntilChanged()` checks equality for every downstream subscriptions, which is unnecessary. 

This PR moved the comparison to upstream to be shared by all subscriptions. It's a small fix that may have pretty decent performance gain. 

Note that we could also use `subject.distinctUntilChanged().shared()` but that is an extra layer of multicasting. 

@BenSchwab @gpeal @elihart 