### PR TITLE
Improve impure error messages

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -91,7 +91,8 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
                             .map { it as KProperty1<S, *> }
                             .first { it.get(firstState) != it.get(secondState) }
                     throw IllegalArgumentException("Your reducer must be pure! ${changedProp.name} changed from " +
-                            "${changedProp.get(firstState)} to ${changedProp.get(secondState)}")
+                            "${changedProp.get(firstState)} to ${changedProp.get(secondState)}. " +
+                            "Ensure that your state properties properly implement hashCode.")
                 }
                 mutableStateChecker.onStateChanged(firstState)
 


### PR DESCRIPTION
Previously, MvRx would just throw an exception that said "Your reducer is not pure!".
However, they will now say:
`Your reducer is not pure! count changed from 1 to Ensure that your state properties properly implement hashCode.` Note that it says the actual property that changed and what it changed to.

It will also highlight if you forgot `data` on one of your Kotlin classes because the toString() will not be formatted.

@BenSchwab @hellohuanlin @elihart 