### PR TITLE
Make it easier to test state

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -497,4 +497,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     }
 
     override fun toString(): String = "${this::class.simpleName} $state"
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal fun getStateForTestRuleDoNotCallOnYourOwn() = state
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverrides.java
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverrides.java
@@ -1,5 +1,9 @@
 package com.airbnb.mvrx;
 
+import android.annotation.SuppressLint;
+import android.support.annotation.RestrictTo;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
 public class MvRxTestOverrides {
     /**
      * This should only be set by the MvRxTestRule from the mvrx-testing artifact.
@@ -8,4 +12,5 @@ public class MvRxTestOverrides {
      * This is Java so it can be packgage private.
      */
     static Boolean FORCE_DEBUG = null;
+
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesKt.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesKt.kt
@@ -1,0 +1,12 @@
+package com.airbnb.mvrx
+
+import android.annotation.SuppressLint
+import android.support.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+object MvRxTestOverridesKt {
+    @SuppressLint("RestrictedApi")
+    fun <S : MvRxState> getStateForTestRuleDoNotCallOnYourOwn(viewModel: BaseMvRxViewModel<S>): S {
+        return viewModel.getStateForTestRuleDoNotCallOnYourOwn()
+    }
+}

--- a/testing/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesProxy.java
+++ b/testing/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesProxy.java
@@ -14,3 +14,4 @@ public class MvRxTestOverridesProxy {
         MvRxTestOverrides.FORCE_DEBUG = debug;
     }
 }
+

--- a/testing/src/main/kotlin/com/airbnb/mvrx/test/MvRxTestRule.kt
+++ b/testing/src/main/kotlin/com/airbnb/mvrx/test/MvRxTestRule.kt
@@ -1,19 +1,16 @@
 package com.airbnb.mvrx.test
 
-import android.support.annotation.NonNull
+import com.airbnb.mvrx.BaseMvRxViewModel
+import com.airbnb.mvrx.MvRxState
+import com.airbnb.mvrx.MvRxTestOverridesKt
 import com.airbnb.mvrx.MvRxTestOverridesProxy
-import io.reactivex.Scheduler
 import io.reactivex.android.plugins.RxAndroidPlugins
-import io.reactivex.disposables.Disposable
 import io.reactivex.exceptions.CompositeException
-import io.reactivex.internal.schedulers.ExecutorScheduler
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.util.concurrent.Executor
-import java.util.concurrent.TimeUnit
 
 enum class DebugMode(internal val value: Boolean?) {
     Debug(true),
@@ -73,4 +70,9 @@ class MvRxTestRule(
         defaultExceptionHandler = null
         RxJavaPlugins.reset()
     }
+
+    /**
+     * Call this to synchronously get the state of your ViewModel to run assertions on it.
+     */
+    fun <S : MvRxState> getState(viewModel: BaseMvRxViewModel<S>) = MvRxTestOverridesKt.getStateForTestRuleDoNotCallOnYourOwn(viewModel)
 }

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     kapt "android.arch.persistence.room:compiler:$roomVersion"
     implementation 'com.android.support.test.espresso:espresso-idling-resource:3.0.2'
     debugImplementation 'com.amitshekhar.android:debug-db:1.0.4'
+    testImplementation project(':testing')
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'

--- a/todomvrx/src/test/java/com/airbnb/mvrx/todomvrx/TaskListViewModelTest.kt
+++ b/todomvrx/src/test/java/com/airbnb/mvrx/todomvrx/TaskListViewModelTest.kt
@@ -1,0 +1,30 @@
+package com.airbnb.mvrx.todomvrx
+
+import com.airbnb.mvrx.test.MvRxTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+
+class TaskListViewModelTest {
+    private lateinit var viewModel: TaskListViewModel
+
+    @Before
+    fun setup() {
+        viewModel = TaskListViewModel(TaskListState())
+    }
+
+    @Test
+    fun testCanChangeTaskListFilter() {
+        viewModel.setFilter(TaskListFilter.All)
+        assertEquals(mvrxTestRule.getState(viewModel).filter, TaskListFilter.All)
+        viewModel.setFilter(TaskListFilter.Active)
+        assertEquals(mvrxTestRule.getState(viewModel).filter, TaskListFilter.Active)
+    }
+
+    companion object {
+        @JvmField
+        @ClassRule
+        val mvrxTestRule = MvRxTestRule()
+    }
+}


### PR DESCRIPTION
This adds a `getState` helper to `MvRxTestRule` to make it possible to test state updates without nasty or awkward hacks.

The code to proxy the state is a bit funky to prevent it from getting exposed but that is done to keep the public API cleaner.

@BenSchwab @hellohuanlin @elihart 