### PR TITLE
update dad joke search function to be async

### DIFF
--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexViewModel.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexViewModel.kt
@@ -12,6 +12,7 @@ import com.airbnb.mvrx.sample.models.Joke
 import com.airbnb.mvrx.sample.models.JokesResponse
 import com.airbnb.mvrx.sample.network.DadJokeService
 import org.koin.android.ext.android.inject
+import java.util.concurrent.TimeUnit
 
 private const val JOKES_PER_PAGE = 5
 
@@ -39,8 +40,9 @@ class DadJokeIndexViewModel(
 
         dadJokeService
                 .search(page = state.jokes.size / JOKES_PER_PAGE + 1, limit = JOKES_PER_PAGE)
+                // Use delay to mimic async behavior
+                .delay(1, TimeUnit.MILLISECONDS)
                 .execute { copy(request = it, jokes = jokes + (it()?.results ?: emptyList())) }
-
     }
 
     /**

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexViewModel.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexViewModel.kt
@@ -11,8 +11,8 @@ import com.airbnb.mvrx.sample.core.MvRxViewModel
 import com.airbnb.mvrx.sample.models.Joke
 import com.airbnb.mvrx.sample.models.JokesResponse
 import com.airbnb.mvrx.sample.network.DadJokeService
+import io.reactivex.schedulers.Schedulers
 import org.koin.android.ext.android.inject
-import java.util.concurrent.TimeUnit
 
 private const val JOKES_PER_PAGE = 5
 
@@ -40,8 +40,7 @@ class DadJokeIndexViewModel(
 
         dadJokeService
                 .search(page = state.jokes.size / JOKES_PER_PAGE + 1, limit = JOKES_PER_PAGE)
-                // Use delay to mimic async behavior
-                .delay(1, TimeUnit.MILLISECONDS)
+                .subscribeOn(Schedulers.io())
                 .execute { copy(request = it, jokes = jokes + (it()?.results ?: emptyList())) }
     }
 


### PR DESCRIPTION
What's expected: 

If we call `fetchNextPage()` twice in init: 
```
init {
  fetchNextPage()
  fetchNextPage()
}
```
The second call should be short circuited by `is Loading` check

In original implementation, this doesn't work (i.e. `is Loading` check is never true), because the dummy search function emits Success state synchronously. This PR simply defer the execution to make it async. 

@BenSchwab @elihart @gpeal 