### PR TITLE
Add select function.

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -505,6 +505,31 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
             .distinctUntilChanged()
             .subscribeLifecycle(owner, uniqueOnly, subscriber)
 
+    /**
+     * Select state changes for subscription.
+     */
+    protected fun <T> select(selector: S.() -> T) = selectInternal(null, false, selector)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun <T> select(
+        owner: LifecycleOwner,
+        uniqueOnly: Boolean,
+        selector: S.() -> T
+    ) = selectInternal(owner, uniqueOnly, selector)
+
+    private fun <T> selectInternal(
+        owner: LifecycleOwner?,
+        uniqueOnly: Boolean,
+        selector: S.() -> T
+    ): MvRxSubscriber<T> {
+        val subscriber = DefaultSubscriber<T>()
+        stateStore.observable
+            .map { it.selector() }
+            .distinctUntilChanged()
+            .subscribeLifecycle(owner, uniqueOnly) { subscriber.emit(it) }
+        return subscriber
+    }
+
     private fun <T> Observable<T>.subscribeLifecycle(
         lifecycleOwner: LifecycleOwner? = null,
         uniqueOnly: Boolean,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -479,6 +479,32 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
             .distinctUntilChanged()
             .subscribeLifecycle(owner, uniqueOnly) { (a, b, c, d, e, f, g) -> subscriber(a, b, c, d, e, f, g) }
 
+    /**
+     * Subscribe to state changes for custom mapping of the state.
+     */
+    protected fun <T> selectSubscribe(
+            selector: S.() -> T,
+            subscriber: (T) -> Unit
+    ) = selectSubscribeInternal(null, selector, false, subscriber)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun <T> selectSubscribe(
+            owner: LifecycleOwner,
+            selector: S.() -> T,
+            uniqueOnly: Boolean,
+            subscriber: (T) -> Unit
+    ) = selectSubscribeInternal(owner, selector, uniqueOnly, subscriber)
+
+    private fun <T> selectSubscribeInternal(
+            owner: LifecycleOwner?,
+            selector: S.() -> T,
+            uniqueOnly: Boolean,
+            subscriber: (T) -> Unit
+    ) = stateStore.observable
+            .map { it.selector() }
+            .distinctUntilChanged()
+            .subscribeLifecycle(owner, uniqueOnly, subscriber)
+
     private fun <T> Observable<T>.subscribeLifecycle(
         lifecycleOwner: LifecycleOwner? = null,
         uniqueOnly: Boolean,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxState.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxState.kt
@@ -9,4 +9,7 @@ package com.airbnb.mvrx
  * that takes a parcelable object. If the Fragment that initializes this ViewModel has an argument
  * at [MvRx.KEY_ARG], it will be passed to your secondary constructor automatically.
  */
-interface MvRxState
+interface MvRxState {
+
+    operator fun <A> A.unaryPlus() = tuple(this)
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxSubscriber.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxSubscriber.kt
@@ -1,0 +1,19 @@
+package com.airbnb.mvrx
+
+interface MvRxSubscriber<T> {
+
+    fun subscribe(subscriber: (T) -> Unit)
+}
+
+internal class DefaultSubscriber<T> : MvRxSubscriber<T> {
+
+    private var subscriber: (T) -> Unit = {}
+
+    override fun subscribe(subscriber: (T) -> Unit) {
+        this.subscriber = subscriber
+    }
+
+    fun emit(value: T) {
+        subscriber(value)
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTuples.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxTuples.kt
@@ -1,9 +1,27 @@
 package com.airbnb.mvrx
 
-internal data class MvRxTuple1<A>(val a: A)
-internal data class MvRxTuple2<A, B>(val a: A, val b: B)
-internal data class MvRxTuple3<A, B, C>(val a: A, val b: B, val c: C)
-internal data class MvRxTuple4<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
-internal data class MvRxTuple5<A, B, C, D, E>(val a: A, val b: B, val c: C, val d: D, val e: E)
-internal data class MvRxTuple6<A, B, C, D, E, F>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F)
-internal data class MvRxTuple7<A, B, C, D, E, F, G>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G)
+data class MvRxTuple1<A>(val a: A)
+data class MvRxTuple2<A, B>(val a: A, val b: B)
+data class MvRxTuple3<A, B, C>(val a: A, val b: B, val c: C)
+data class MvRxTuple4<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
+data class MvRxTuple5<A, B, C, D, E>(val a: A, val b: B, val c: C, val d: D, val e: E)
+data class MvRxTuple6<A, B, C, D, E, F>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F)
+data class MvRxTuple7<A, B, C, D, E, F, G>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G)
+
+/**
+ * MvRxTuple1 is not so useful for [BaseMvRxViewModel.select]
+ */
+fun <A> tuple(a: A) = MvRxTuple1(a)
+fun <A, B> tuple(a: A, b: B) = MvRxTuple2(a, b)
+fun <A, B, C> tuple(a: A, b: B, c: C) = MvRxTuple3(a, b, c)
+fun <A, B, C, D> tuple(a: A, b: B, c: C, d: D) = MvRxTuple4(a, b, c, d)
+fun <A, B, C, D, E> tuple(a: A, b: B, c: C, d: D, e: E) = MvRxTuple5(a, b, c, d, e)
+fun <A, B, C, D, E, F> tuple(a: A, b: B, c: C, d: D, e: E, f: F) = MvRxTuple6(a, b, c, d, e, f)
+fun <A, B, C, D, E, F, G> tuple(a: A, b: B, c: C, d: D, e: E, f: F, g: G) = MvRxTuple7(a, b, c, d, e, f, g)
+
+operator fun <A, B> MvRxTuple1<A>.plus(b: B) = tuple(a, b)
+operator fun <A, B, C> MvRxTuple2<A, B>.plus(c: C) = tuple(a, b, c)
+operator fun <A, B, C, D> MvRxTuple3<A, B, C>.plus(d: D) = tuple(a, b, c, d)
+operator fun <A, B, C, D, E> MvRxTuple4<A, B, C, D>.plus(e: E) = tuple(a, b, c, d, e)
+operator fun <A, B, C, D, E, F> MvRxTuple5<A, B, C, D, E>.plus(f: F) = tuple(a, b, c, d, e, f)
+operator fun <A, B, C, D, E, F, G> MvRxTuple6<A, B, C, D, E, F>.plus(g: G) = tuple(a, b, c, d, e, f, g)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -143,4 +143,27 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
         uniqueOnly: Boolean = false,
         subscriber: (T) -> Unit
     ) = selectSubscribe(this@MvRxView, selector, uniqueOnly, subscriber)
+
+    /**
+     * Returns a [MvRxSubscriber] that can be used to observe state changes.
+     * Compared to the [selectSubscribe] methods, this eliminates the use of reflection and allows to write more
+     * concise code.
+     *
+     * Example usages:
+     *
+     * select { prop1 }.subscribe { prop1 -> ... }
+     *
+     * select { tuple(prop1, prop2) }.subscribe { (prop1, prop2) -> ... }
+     *
+     * which is equivalent to
+     *
+     * select { + prop1 + prop2 }.subscribe { (prop1, prop2) -> ... }
+     *
+     * @param selector a lambda function to get the interested aspects of the state.
+     *
+     */
+    fun <S : MvRxState, T> BaseMvRxViewModel<S>.select(
+        uniqueOnly: Boolean = false,
+        selector: S.() -> T
+    ) = select(this@MvRxView, uniqueOnly, selector)
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -134,4 +134,13 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
         uniqueOnly: Boolean = false,
         subscriber: (A, B, C, D) -> Unit
     ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, uniqueOnly, subscriber)
+
+    /**
+     * Subscribes to state changes for custom mapping of the state.
+     */
+    fun <S : MvRxState, T> BaseMvRxViewModel<S>.selectSubscribe(
+        selector: S.() -> T,
+        uniqueOnly: Boolean = false,
+        subscriber: (T) -> Unit
+    ) = selectSubscribe(this@MvRxView, selector, uniqueOnly, subscriber)
 }


### PR DESCRIPTION
Another option for the `selectSubscribe` methods. It eliminates the use
of reflection and allows to write more concise code.

Sample usage looks like

```
viewModel
    .select { + prop1 + prop2 + prop3 }
    .subscribe{ (p1, p2, p3) -> ... }
```