### PR TITLE
Prevent private props from crashing in debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /local.properties
 .idea
 .DS_Store
-/build
+**/build

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
@@ -3,6 +3,8 @@ package com.airbnb.mvrx
 import org.junit.Test
 
 data class PureReducerValidationState(val count: Int = 0) : MvRxState
+data class StateWithPrivateVal(private val foo: Int = 0) : MvRxState
+
 class PureReducerValidationTest : BaseTest() {
 
     @Test(expected = IllegalArgumentException::class)
@@ -30,5 +32,15 @@ class PureReducerValidationTest : BaseTest() {
             }
         }
         PureViewModel(PureReducerValidationState()).pureReducer()
+    }
+
+    @Test
+    fun shouldBeAbleToUsePrivateProps() {
+        class PureViewModel(initialState: StateWithPrivateVal) : TestMvRxViewModel<StateWithPrivateVal>(initialState) {
+            fun pureReducer() {
+                setState { this }
+            }
+        }
+        PureViewModel(StateWithPrivateVal()).pureReducer()
     }
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
@@ -3,7 +3,7 @@ package com.airbnb.mvrx
 import org.junit.Test
 
 data class PureReducerValidationState(val count: Int = 0) : MvRxState
-data class StateWithPrivateVal(private val foo: Int = 0) : MvRxState
+data class StateWithPrivateVal(private val count: Int = 0) : MvRxState
 
 class PureReducerValidationTest : BaseTest() {
 
@@ -42,5 +42,19 @@ class PureReducerValidationTest : BaseTest() {
             }
         }
         PureViewModel(StateWithPrivateVal()).pureReducer()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun impureReducerWithPrivatePropShouldFail() {
+        class ImpureViewModel(initialState: StateWithPrivateVal) : TestMvRxViewModel<StateWithPrivateVal>(initialState) {
+            private var count = 0
+            fun impureReducer() {
+                setState {
+                    val state = copy(count = ++this@ImpureViewModel.count)
+                    state
+                }
+            }
+        }
+        ImpureViewModel(StateWithPrivateVal()).impureReducer()
     }
 }


### PR DESCRIPTION
Our reflection cache warming was crashing on private props.
The test failed before this change and passed after.

@BenSchwab 