### PR TITLE
Add new keep rule for MvRxViewModelFactory without JvmStatic and initialState

### DIFF
--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -12,12 +12,22 @@
 
 # Classes extending BaseMvRxViewModel are recreated using reflection, which assumes that a one argument
 # constructor accepting a data class holding the state exists. Need to make sure to keep the constructor
-# around. Additionally, a static create method will be generated in the case a companion object factory
-# is used. This is accessed via reflection.
+# around. Additionally, a static create / inital state method will be generated in the case a
+# companion object factory is used with JvmStatic. This is accessed via reflection.
 -keepclassmembers class ** extends com.airbnb.mvrx.BaseMvRxViewModel {
     public <init>(...);
     public static *** create(...);
+    public static *** initialState(...);
 }
+
+# If a MvRxViewModelFactory is used with JvmStatic, keep create and initalState methods which
+# are accessed via reflection.
+-keepclassmembers class ** implements com.airbnb.mvrx.MvRxViewModelFactory {
+     public <init>(...);
+     public *** create(...);
+     public *** initialState(...);
+}
+
 
 # Members of the Kotlin data classes used as the state in MvRx are read via Kotlin reflection which cause trouble
 # with Proguard if they are not kept.

--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -20,7 +20,7 @@
     public static *** initialState(...);
 }
 
-# If a MvRxViewModelFactory is used with JvmStatic, keep create and initalState methods which
+# If a MvRxViewModelFactory is used without JvmStatic, keep create and initalState methods which
 # are accessed via reflection.
 -keepclassmembers class ** implements com.airbnb.mvrx.MvRxViewModelFactory {
      public <init>(...);

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -155,6 +155,7 @@
 #
 
 -keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+-keep class kotlin.reflect.jvm.internal.impl.serialization.deserialization.builtins.BuiltInsLoaderImpl
 
 -keepclassmembers class kotlin.Metadata {
     public <methods>;

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeDetailFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeDetailFragment.kt
@@ -42,7 +42,8 @@ class DadJokeDetailViewModel(
     }
 
     companion object : MvRxViewModelFactory<DadJokeDetailViewModel, DadJokeDetailState> {
-        override fun create(viewModelContext: ViewModelContext, state: DadJokeDetailState): DadJokeDetailViewModel {
+        // Intentionally leaving unnecessary JvmStatic to test Proguard rules.
+        @JvmStatic override fun create(viewModelContext: ViewModelContext, state: DadJokeDetailState): DadJokeDetailViewModel {
             val service: DadJokeService by viewModelContext.activity.inject()
             return DadJokeDetailViewModel(state, service)
         }


### PR DESCRIPTION
https://github.com/airbnb/MvRx/pull/169 Added a new `initialState` method and ability to not use `@JvmStatic` all of these need keep rules.

Closes https://github.com/airbnb/MvRx/issues/176

** Note: Kotlin 1.3+ requires this keep rule as well:

`keep class kotlin.reflect.jvm.internal.impl.serialization.deserialization.builtins.BuiltInsLoaderImpl`

Per the discussion in https://github.com/airbnb/MvRx/pull/138, this is not a project specific rule, so not including it in the proguard file, but updated wiki to suggest it.

Tested on sample app.

Created https://github.com/airbnb/MvRx/issues/182 to prevent this from the future. Would be a great first task if anyone from the community wants to jump on it :)

@gpeal @rossbacher 