### PR TITLE
 Allow for injectable ViewModel factories

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
@@ -23,9 +23,10 @@ import kotlin.reflect.KProperty
  */
 inline fun <T, reified VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.fragmentViewModel(
     viewModelClass: KClass<VM> = VM::class,
-    crossinline keyFactory: () -> String = { viewModelClass.java.name }
+    crossinline keyFactory: () -> String = { viewModelClass.java.name },
+    noinline viewModelFactory: MvRxViewModelProviderFactory<VM>? = null
 ) where T : Fragment, T : MvRxView = lifecycleAwareLazy(this) {
-    MvRxViewModelProvider.get(viewModelClass.java, S::class.java, FragmentViewModelContext(this.requireActivity(), _fragmentArgsProvider(), this), keyFactory())
+    MvRxViewModelProvider.get(viewModelClass.java, S::class.java, FragmentViewModelContext(this.requireActivity(), _fragmentArgsProvider(), this), keyFactory(), viewModelFactory)
         .apply { subscribe(this@fragmentViewModel, subscriber = { postInvalidate() }) }
 }
 
@@ -47,10 +48,11 @@ inline fun <T, reified VM : BaseMvRxViewModel<S>, S : MvRxState> T.existingViewM
  */
 inline fun <T, reified VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.activityViewModel(
     viewModelClass: KClass<VM> = VM::class,
-    noinline keyFactory: () -> String = { viewModelClass.java.name }
+    crossinline keyFactory: () -> String = { viewModelClass.java.name },
+    noinline viewModelFactory: MvRxViewModelProviderFactory<VM>? = null
 ) where T : Fragment, T : MvRxView = lifecycleAwareLazy(this) {
     if (requireActivity() !is MvRxViewModelStoreOwner) throw IllegalArgumentException("Your Activity must be a MvRxViewModelStoreOwner!")
-    MvRxViewModelProvider.get(viewModelClass.java, S::class.java, ActivityViewModelContext(requireActivity(), _activityArgsProvider(keyFactory)), keyFactory())
+    MvRxViewModelProvider.get(viewModelClass.java, S::class.java, ActivityViewModelContext(requireActivity(), _activityArgsProvider(keyFactory)), keyFactory(), viewModelFactory)
         .apply { subscribe(this@activityViewModel, subscriber = { postInvalidate() }) }
 }
 
@@ -89,10 +91,11 @@ inline fun <T : Fragment> T._activityArgsProvider(keyFactory: () -> String): Any
  */
 inline fun <T, reified VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.viewModel(
     viewModelClass: KClass<VM> = VM::class,
-    crossinline keyFactory: () -> String = { viewModelClass.java.name }
+    crossinline keyFactory: () -> String = { viewModelClass.java.name },
+    noinline viewModelFactory: MvRxViewModelProviderFactory<VM>? = null
 ) where T : FragmentActivity,
         T : MvRxViewModelStoreOwner = lifecycleAwareLazy(this) {
-    MvRxViewModelProvider.get(viewModelClass.java, S::class.java, ActivityViewModelContext(this, intent.extras?.get(MvRx.KEY_ARG)), keyFactory())
+    MvRxViewModelProvider.get(viewModelClass.java, S::class.java, ActivityViewModelContext(this, intent.extras?.get(MvRx.KEY_ARG)), keyFactory(), viewModelFactory)
 }
 
 /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -6,6 +6,8 @@ import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentActivity
 import kotlin.reflect.full.primaryConstructor
 
+typealias MvRxViewModelProviderFactory<VM> = () -> VM
+
 /**
  * Helper ViewModelProvider that has a single method for taking either a [Fragment] or [FragmentActivity] instead
  * of two separate ones. The logic for providing the correct scope is inside the method.
@@ -27,10 +29,11 @@ object MvRxViewModelProvider {
         viewModelClass: Class<VM>,
         stateClass: Class<S>,
         viewModelContext: ViewModelContext,
-        key: String = viewModelClass.name
+        key: String = viewModelClass.name,
+        viewModelFactory: MvRxViewModelProviderFactory<VM>? = null
     ): VM {
         // This wraps the fact that ViewModelProvider.of has individual methods for Fragment and FragmentActivity.
-        val factory = MvRxFactory { createViewModel(viewModelClass, stateClass, viewModelContext) }
+        val factory = MvRxFactory { viewModelFactory?.invoke() ?: createViewModel(viewModelClass, stateClass, viewModelContext) }
         return when (viewModelContext) {
             is ActivityViewModelContext -> ViewModelProviders.of(viewModelContext.activity, factory)
             is FragmentViewModelContext -> ViewModelProviders.of(viewModelContext.fragment, factory)

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
@@ -121,6 +121,8 @@ class FactoryViewModelTest : BaseTest() {
         }
     }
 
+    private class TestInjectedFactoryViewModel(initialState: FactoryState, val otherProp: Long) : TestMvRxViewModel<FactoryState>(initialState)
+
     private class TestFactoryJvmStaticViewModel(initialState: FactoryState, val otherProp: Long) : TestMvRxViewModel<FactoryState>(initialState) {
         companion object : MvRxViewModelFactory<TestFactoryJvmStaticViewModel, FactoryState> {
             @JvmStatic
@@ -178,6 +180,44 @@ class FactoryViewModelTest : BaseTest() {
             assertEquals(FactoryState("hello constructor"), state)
         }
         assertEquals(5, viewModel.otherProp)
+    }
+
+    @Test
+    fun createWithInjectedViewModelFactory() {
+        val (_, fragment) = createFragment<ViewModelFactoryTestFragment, TestActivity>()
+        fragment.arguments = Bundle().apply { putLong("otherProp", 6L) }
+
+        val arguments = TestArgs("hello")
+        val context = FragmentViewModelContext(activity, arguments, fragment)
+        val curriedFactory = { args: TestArgs, otherProp: Long ->
+            { TestInjectedFactoryViewModel(FactoryState(args), otherProp) }
+        }
+
+        val factory = curriedFactory(arguments, fragment.arguments!!.getLong("otherProp"))
+        val viewModel = MvRxViewModelProvider.get(TestInjectedFactoryViewModel::class.java, FactoryState::class.java, context, viewModelFactory = factory)
+        withState(viewModel) { state ->
+            assertEquals(FactoryState("hello constructor"), state)
+        }
+        assertEquals(6, viewModel.otherProp)
+    }
+
+    @Test
+    fun createWithInjectedViewModelFactoryUsingCompanionObject() {
+        val (_, fragment) = createFragment<ViewModelFactoryTestFragment, TestActivity>()
+        fragment.arguments = Bundle().apply { putLong("otherProp", 6L) }
+
+        val arguments = TestArgs("hello")
+        val context = FragmentViewModelContext(activity, arguments, fragment)
+        val curriedFactory = { args: TestArgs, otherProp: Long ->
+            { TestInjectedFactoryViewModel(FactoryState(args), otherProp) }
+        }
+
+        val factory = curriedFactory(arguments, fragment.arguments!!.getLong("otherProp"))
+        val viewModel = MvRxViewModelProvider.get(TestInjectedFactoryViewModel::class.java, FactoryState::class.java, context, viewModelFactory = factory)
+        withState(viewModel) { state ->
+            assertEquals(FactoryState("hello constructor"), state)
+        }
+        assertEquals(6, viewModel.otherProp)
     }
 
     @Test


### PR DESCRIPTION
Instead of accessing an injected ViewModel Factory via the companion object context I've since found it easier to just sidestep the reflection and directly inject the ViewModel Factory into the ViewModelProvider.

This makes it even easier when using dagger #69 cause you can inject the Factory like this

```kotlin
@Inject lateinit var viewModelFactory: UserDetailViewModel.Factory

private val userDetailViewModel: UserDetailViewModel by fragmentViewModel {
    viewModelFactory.create(arguments!!.getLong("USER_ID"))
}
```

Feedback on adding this approch would be appreciated.