### PR TITLE
Respect unique only on configuration changes.

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -2,6 +2,7 @@ package com.airbnb.mvrx
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import java.util.*
 
 /**
  * Make your base Fragment class extend this to get MvRx functionality.
@@ -12,14 +13,20 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
 
     override val mvrxViewModelStore by lazy { MvRxViewModelStore(viewModelStore) }
 
+    final override val mvrxViewId: String by lazy { mvrxPersistedViewId }
+
+    private lateinit var mvrxPersistedViewId: String
+
     override fun onCreate(savedInstanceState: Bundle?) {
         mvrxViewModelStore.restoreViewModels(this, savedInstanceState)
+        mvrxPersistedViewId = savedInstanceState?.getString(PERSISTED_VIEW_ID_KEY) ?: UUID.randomUUID().toString()
         super.onCreate(savedInstanceState)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         mvrxViewModelStore.saveViewModels(outState)
+        outState.putString(PERSISTED_VIEW_ID_KEY, mvrxViewId)
     }
 
     override fun onStart() {
@@ -29,3 +36,5 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
         postInvalidate()
     }
 }
+
+private const val PERSISTED_VIEW_ID_KEY = "mvrx:persisted_view_id"

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -19,7 +19,7 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         mvrxViewModelStore.restoreViewModels(this, savedInstanceState)
-        mvrxPersistedViewId = savedInstanceState?.getString(PERSISTED_VIEW_ID_KEY) ?: UUID.randomUUID().toString()
+        mvrxPersistedViewId = savedInstanceState?.getString(PERSISTED_VIEW_ID_KEY) ?: this::class.java.simpleName + "_" + UUID.randomUUID().toString()
         super.onCreate(savedInstanceState)
     }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -215,10 +215,10 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      * For ViewModels that want to subscribe to itself.
      */
     protected fun subscribe(subscriber: (S) -> Unit) =
-        stateStore.observable.subscribeLifecycle(null, Standard, subscriber)
+        stateStore.observable.subscribeLifecycle(null, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    fun subscribe(owner: LifecycleOwner, deliveryMode: DeliveryMode = Standard, subscriber: (S) -> Unit) =
+    fun subscribe(owner: LifecycleOwner, deliveryMode: DeliveryMode = RedeliverOnStart, subscriber: (S) -> Unit) =
         stateStore.observable.subscribeLifecycle(owner, deliveryMode, subscriber)
 
     /**
@@ -227,13 +227,13 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     protected fun <A> selectSubscribe(
         prop1: KProperty1<S, A>,
         subscriber: (A) -> Unit
-    ) = selectSubscribeInternal(null, prop1, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A> selectSubscribe(
         owner: LifecycleOwner,
         prop1: KProperty1<S, A>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A) -> Unit
     ) = selectSubscribeInternal(owner, prop1, deliveryMode, subscriber)
 
@@ -255,13 +255,13 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         asyncProp: KProperty1<S, Async<T>>,
         onFail: ((Throwable) -> Unit)? = null,
         onSuccess: ((T) -> Unit)? = null
-    ) = asyncSubscribeInternal(null, asyncProp, Standard, onFail, onSuccess)
+    ) = asyncSubscribeInternal(null, asyncProp, RedeliverOnStart, onFail, onSuccess)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <T> asyncSubscribe(
         owner: LifecycleOwner,
         asyncProp: KProperty1<S, Async<T>>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         onFail: ((Throwable) -> Unit)? = null,
         onSuccess: ((T) -> Unit)? = null
     ) = asyncSubscribeInternal(owner, asyncProp, deliveryMode, onFail, onSuccess)
@@ -287,14 +287,14 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         subscriber: (A, B) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, prop2, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B> selectSubscribe(
         owner: LifecycleOwner,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, deliveryMode, subscriber)
 
@@ -317,7 +317,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
         subscriber: (A, B, C) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, prop3, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, prop2, prop3, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C> selectSubscribe(
@@ -325,7 +325,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, prop3, deliveryMode, subscriber)
 
@@ -350,7 +350,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop3: KProperty1<S, C>,
         prop4: KProperty1<S, D>,
         subscriber: (A, B, C, D) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D> selectSubscribe(
@@ -359,7 +359,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
         prop4: KProperty1<S, D>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C, D) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, prop3, prop4, deliveryMode, subscriber)
 
@@ -386,7 +386,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop4: KProperty1<S, D>,
         prop5: KProperty1<S, E>,
         subscriber: (A, B, C, D, E) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D, E> selectSubscribe(
@@ -396,7 +396,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop3: KProperty1<S, C>,
         prop4: KProperty1<S, D>,
         prop5: KProperty1<S, E>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C, D, E) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, prop3, prop4, prop5, deliveryMode, subscriber)
 
@@ -425,7 +425,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop5: KProperty1<S, E>,
         prop6: KProperty1<S, F>,
         subscriber: (A, B, C, D, E, F) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, prop6, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, prop6, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D, E, F> selectSubscribe(
@@ -436,7 +436,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop4: KProperty1<S, D>,
         prop5: KProperty1<S, E>,
         prop6: KProperty1<S, F>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C, D, E, F) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, prop3, prop4, prop5, prop6, deliveryMode, subscriber)
 
@@ -467,7 +467,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop6: KProperty1<S, F>,
         prop7: KProperty1<S, G>,
         subscriber: (A, B, C, D, E, F, G) -> Unit
-    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, prop6, prop7, Standard, subscriber)
+    ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, prop6, prop7, RedeliverOnStart, subscriber)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D, E, F, G> selectSubscribe(
@@ -479,7 +479,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop5: KProperty1<S, E>,
         prop6: KProperty1<S, F>,
         prop7: KProperty1<S, G>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C, D, E, F, G) -> Unit
     ) = selectSubscribeInternal(owner, prop1, prop2, prop3, prop4, prop5, prop6, prop7, deliveryMode, subscriber)
 
@@ -519,7 +519,8 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
             lastDeliveredValue = if (deliveryMode is UniqueOnly) {
                 if (activeSubscriptions.contains(deliveryMode.subscriptionId)) {
                     throw IllegalStateException("Subscribing with a duplicate subscription id: ${deliveryMode.subscriptionId}. " +
-                        "If you have multiple unique only subscriptions in a MvRx view that listen to the same")
+                        "If you have multiple uniqueOnly subscriptions in a MvRx view that listen to the same properties " +
+                        "you must use a custom subscription id.")
                 }
                 activeSubscriptions.add(deliveryMode.subscriptionId)
                 lastDeliveredStates[deliveryMode.subscriptionId] as? T
@@ -553,13 +554,13 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
 
 /**
  * Defines what updates a subscription should receive.
- * See: [Standard], [UniqueOnly].
+ * See: [RedeliverOnStart], [UniqueOnly].
  */
 sealed class DeliveryMode {
 
     internal fun appendPropertiesToId(vararg properties: KProperty1<*, *>) : DeliveryMode {
         return when (this) {
-            is Standard -> Standard
+            is RedeliverOnStart -> RedeliverOnStart
             is UniqueOnly -> UniqueOnly(subscriptionId + "_" + properties.joinToString(",") { it.name })
         }
     }
@@ -569,15 +570,15 @@ sealed class DeliveryMode {
  * The subscription will receive the most recent state update when transitioning from locked to unlocked states (stopped -> started),
  * even if the state has not changed while locked.
  *
- * Likewise,  when a MvRxView resubscribes after a configuration change the most recent update will always be emitted.
+ * Likewise, when a MvRxView resubscribes after a configuration change the most recent update will always be emitted.
  */
-object Standard : DeliveryMode()
+object RedeliverOnStart : DeliveryMode()
 
 /**
  * The subscription will receive the most recent state update when transitioning from locked to unlocked states (stopped -> started),
  * only if the state has changed while locked.
  *
- * Likewise,  when a MvRxView resubscribes after a configuration change the most recent update will only be emitted
+ * Likewise, when a MvRxView resubscribes after a configuration change the most recent update will only be emitted
  * if the state has changed while locked.
  *
  * @param subscriptionId A uniqueIdentifier for this subscription. It is an error for two unique only subscriptions to

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
@@ -26,7 +26,8 @@ internal class MvRxLifecycleAwareObserver<T : Any>(
     private val activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
     private val deliveryMode: DeliveryMode = Standard,
     private var lastDeliveredValueFromPriorObserver: T?,
-    private var sourceObserver: Observer<T>?
+    private var sourceObserver: Observer<T>?,
+    private val onDispose: () -> Unit
 ) : AtomicReference<Disposable>(), LifecycleObserver, Observer<T>, Disposable {
 
     constructor(
@@ -37,8 +38,9 @@ internal class MvRxLifecycleAwareObserver<T : Any>(
         onComplete: Action = Functions.EMPTY_ACTION,
         onSubscribe: Consumer<in Disposable> = Functions.emptyConsumer(),
         onError: Consumer<in Throwable> = Functions.ON_ERROR_MISSING,
-        onNext: Consumer<T> = Functions.emptyConsumer()
-    ) : this(owner, activeState, deliveryMode, lastDeliveredValue, LambdaObserver<T>(onNext, onError, onComplete, onSubscribe))
+        onNext: Consumer<T> = Functions.emptyConsumer(),
+        onDispose: () ->  Unit
+    ) : this(owner, activeState, deliveryMode, lastDeliveredValue, LambdaObserver<T>(onNext, onError, onComplete, onSubscribe), onDispose)
 
     private var lastUndeliveredValue: T? = null
     private var lastValue: T? = null
@@ -105,6 +107,7 @@ internal class MvRxLifecycleAwareObserver<T : Any>(
 
     override fun dispose() {
         DisposableHelper.dispose(this)
+        onDispose()
     }
 
     override fun isDisposed(): Boolean {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareObserver.kt
@@ -21,26 +21,31 @@ import java.util.concurrent.atomic.AtomicReference
  * than the [activeState] (as defined by [Lifecycle.State.isAtLeast()]) it will deliver values to the [sourceObserver] or [onNext] lambda.
  * When in a lower lifecycle state, the most recent update will be saved, and delivered when active again.
  */
-internal class MvRxLifecycleAwareObserver<T>(
+internal class MvRxLifecycleAwareObserver<T : Any>(
     private var owner: LifecycleOwner?,
     private val activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
-    private val alwaysDeliverLastValueWhenUnlocked: Boolean = false,
+    private val deliveryMode: DeliveryMode = Standard,
+    private var lastDeliveredValueFromPriorObserver: T?,
     private var sourceObserver: Observer<T>?
 ) : AtomicReference<Disposable>(), LifecycleObserver, Observer<T>, Disposable {
 
     constructor(
         owner: LifecycleOwner,
         activeState: Lifecycle.State = DEFAULT_ACTIVE_STATE,
-        alwaysDeliverLastValueWhenUnlocked: Boolean = false,
+        deliveryMode: DeliveryMode = Standard,
+        lastDeliveredValue: T? = null,
         onComplete: Action = Functions.EMPTY_ACTION,
         onSubscribe: Consumer<in Disposable> = Functions.emptyConsumer(),
         onError: Consumer<in Throwable> = Functions.ON_ERROR_MISSING,
         onNext: Consumer<T> = Functions.emptyConsumer()
-    ) : this(owner, activeState, alwaysDeliverLastValueWhenUnlocked, LambdaObserver<T>(onNext, onError, onComplete, onSubscribe))
+    ) : this(owner, activeState, deliveryMode, lastDeliveredValue, LambdaObserver<T>(onNext, onError, onComplete, onSubscribe))
 
     private var lastUndeliveredValue: T? = null
     private var lastValue: T? = null
     private val locked = AtomicBoolean(true)
+    private val isUnlocked
+        get() = !locked.get()
+    private val deliveredFirstValue = AtomicBoolean(false)
 
     override fun onSubscribe(d: Disposable) {
         if (DisposableHelper.setOnce(this, d)) {
@@ -72,13 +77,19 @@ internal class MvRxLifecycleAwareObserver<T>(
         }
     }
 
-    override fun onNext(t: T) {
-        if (!locked.get()) {
-            requireSourceObserver().onNext(t)
+    override fun onNext(nextValue: T) {
+        if (isUnlocked) {
+            val suppressRepeatedFirstValue = !deliveredFirstValue.getAndSet(true)
+                && deliveryMode is UniqueOnly
+                && lastDeliveredValueFromPriorObserver == nextValue
+            lastDeliveredValueFromPriorObserver = null
+            if (!suppressRepeatedFirstValue) {
+                requireSourceObserver().onNext(nextValue)
+            }
         } else {
-            lastUndeliveredValue = t
+            lastUndeliveredValue = nextValue
         }
-        lastValue = t
+        lastValue = nextValue
     }
 
     override fun onError(e: Throwable) {
@@ -105,7 +116,12 @@ internal class MvRxLifecycleAwareObserver<T>(
             return
         }
         if (!isDisposed) {
-            val valueToDeliverOnUnlock = if (alwaysDeliverLastValueWhenUnlocked && lastValue != null) lastValue else lastUndeliveredValue
+            val valueToDeliverOnUnlock = when {
+                deliveryMode is UniqueOnly -> lastUndeliveredValue
+                deliveryMode is Standard && lastUndeliveredValue != null -> lastUndeliveredValue
+                deliveryMode is Standard && lastUndeliveredValue == null -> lastValue
+                else -> throw IllegalStateException("Value to deliver on unlock should be exhaustive.")
+            }
             lastUndeliveredValue = null
             if (valueToDeliverOnUnlock != null) {
                 onNext(valueToDeliverOnUnlock)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -25,10 +25,12 @@ private val handler = Handler(Looper.getMainLooper(), Handler.Callback { message
 interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
 
     /**
-     * A globally unique id for this MvRxView. If your MvRxView is being recreated due to a lifecycle event (e.g. rotation)
-     * you should assign a consistent id. Likely this means you should save the id in onSaveInstance state.
-     * The viewId will not be accessed until a subscribe method is called. Accessing mvrxViewId before calling
-     * super.onCreate() will cause a crash.
+     * Override this to supply a globally unique id for this MvRxView. If your MvRxView is being recreated due to
+     * a lifecycle event (e.g. rotation) you should assign a consistent id. Likely this means you should save the id
+     * in onSaveInstance state. The viewId will not be accessed until a subscribe method is called.
+     * Accessing mvrxViewId before calling super.onCreate() will cause a crash.
+     *
+     * For an example implementation see [BaseMvRxFragment].
      */
     val mvrxViewId: String
 
@@ -53,9 +55,9 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      *
      * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
      *
-     * Default: [Standard].
+     * Default: [RedeliverOnStart].
      */
-    fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(deliveryMode: DeliveryMode = Standard, subscriber: (S) -> Unit) = subscribe(this@MvRxView, deliveryMode, subscriber)
+    fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(deliveryMode: DeliveryMode = RedeliverOnStart, subscriber: (S) -> Unit) = subscribe(this@MvRxView, deliveryMode, subscriber)
 
     /**
      * Subscribes to state changes for only a specific property and calls the subscribe with
@@ -68,11 +70,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      *
      * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
      *
-     * Default: [Standard].
+     * Default: [RedeliverOnStart].
      */
     fun <S : MvRxState, A> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A) -> Unit
     ) = selectSubscribe(this@MvRxView, prop1, deliveryMode, subscriber)
 
@@ -87,11 +89,11 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      *
      * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
      *
-     * Default: [Standard].
+     * Default: [RedeliverOnStart].
      */
     fun <S : MvRxState, T> BaseMvRxViewModel<S>.asyncSubscribe(
         asyncProp: KProperty1<S, Async<T>>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         onFail: ((Throwable) -> Unit)? = null,
         onSuccess: ((T) -> Unit)? = null
     ) = asyncSubscribe(this@MvRxView, asyncProp, deliveryMode, onFail, onSuccess)
@@ -106,12 +108,12 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      *
      * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
      *
-     * Default: [Standard].
+     * Default: [RedeliverOnStart].
      */
     fun <S : MvRxState, A, B> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B) -> Unit
     ) = selectSubscribe(this@MvRxView, prop1, prop2, deliveryMode, subscriber)
 
@@ -125,13 +127,13 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      *
      * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
      *
-     * Default: [Standard].
+     * Default: [RedeliverOnStart].
      */
     fun <S : MvRxState, A, B, C> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C) -> Unit
     ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, deliveryMode, subscriber)
 
@@ -145,14 +147,14 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
      *
      * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
      *
-     * Default: [Standard].
+     * Default: [RedeliverOnStart].
      */
     fun <S : MvRxState, A, B, C, D> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
         prop4: KProperty1<S, D>,
-        deliveryMode: DeliveryMode = Standard,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
         subscriber: (A, B, C, D) -> Unit
     ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, deliveryMode, subscriber)
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -23,6 +23,14 @@ private val handler = Handler(Looper.getMainLooper(), Handler.Callback { message
  * will automatically subscribe to all state changes in the ViewModel and call [invalidate].
  */
 interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
+
+    /**
+     * A globally unique id for this MvRxView. If your MvRxView is being recreated due to a lifecycle event (e.g. rotation)
+     * you should assign a consistent id. Likely this means you should save the id in onSaveInstance state. The
+     * viewId will not be accessed until a subscribe method is called.
+     */
+    val mvrxViewId: String
+
     /**
      * Override this to handle any state changes from MvRxViewModels created through MvRx Fragment delegates.
      */
@@ -37,101 +45,125 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
     /**
      * Subscribes to all state updates for the given viewModel.
      *
-     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.
      *
-     * Default: false.
+     * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
+     *
+     * Default: [Standard].
      */
-    fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(uniqueOnly: Boolean = false, subscriber: (S) -> Unit) = subscribe(this@MvRxView, uniqueOnly, subscriber)
+    fun <S : MvRxState> BaseMvRxViewModel<S>.subscribe(deliveryMode: DeliveryMode = Standard, subscriber: (S) -> Unit) = subscribe(this@MvRxView, deliveryMode, subscriber)
 
     /**
      * Subscribes to state changes for only a specific property and calls the subscribe with
      * only that single property.
      *
-     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.
      *
-     * Default: false.
+     * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
+     *
+     * Default: [Standard].
      */
     fun <S : MvRxState, A> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
-        uniqueOnly: Boolean = false,
+        deliveryMode: DeliveryMode = Standard,
         subscriber: (A) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, uniqueOnly, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, deliveryMode, subscriber)
 
     /**
      * Subscribe to changes in an async property. There are optional parameters for onSuccess
      * and onFail which automatically unwrap the value or error.
      *
-     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.
      *
-     * Default: false.
+     * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
+     *
+     * Default: [Standard].
      */
     fun <S : MvRxState, T> BaseMvRxViewModel<S>.asyncSubscribe(
         asyncProp: KProperty1<S, Async<T>>,
-        uniqueOnly: Boolean = false,
+        deliveryMode: DeliveryMode = Standard,
         onFail: ((Throwable) -> Unit)? = null,
         onSuccess: ((T) -> Unit)? = null
-    ) = asyncSubscribe(this@MvRxView, asyncProp, uniqueOnly, onFail, onSuccess)
+    ) = asyncSubscribe(this@MvRxView, asyncProp, deliveryMode, onFail, onSuccess)
 
     /**
      * Subscribes to state changes for two properties.
      *
-     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.
      *
-     * Default: false.
+     * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
+     *
+     * Default: [Standard].
      */
     fun <S : MvRxState, A, B> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
-        uniqueOnly: Boolean = false,
+        deliveryMode: DeliveryMode = Standard,
         subscriber: (A, B) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, prop2, uniqueOnly, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, deliveryMode, subscriber)
 
     /**
      * Subscribes to state changes for three properties.
      *
-     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.
      *
-     * Default: false.
+     * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
+     *
+     * Default: [Standard].
      */
     fun <S : MvRxState, A, B, C> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
-        uniqueOnly: Boolean = false,
+        deliveryMode: DeliveryMode = Standard,
         subscriber: (A, B, C) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, uniqueOnly, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, deliveryMode, subscriber)
 
     /**
      * Subscribes to state changes for four properties.
      *
-     * @param uniqueOnly If true, when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.
      *
-     * Default: false.
+     * Use [uniqueOnly] to automatically create a [UniqueOnly] mode with a unique id for this view.
+     *
+     * Default: [Standard].
      */
     fun <S : MvRxState, A, B, C, D> BaseMvRxViewModel<S>.selectSubscribe(
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
         prop3: KProperty1<S, C>,
         prop4: KProperty1<S, D>,
-        uniqueOnly: Boolean = false,
+        deliveryMode: DeliveryMode = Standard,
         subscriber: (A, B, C, D) -> Unit
-    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, uniqueOnly, subscriber)
+    ) = selectSubscribe(this@MvRxView, prop1, prop2, prop3, prop4, deliveryMode, subscriber)
+
+    /**
+     * Return a [UniqueOnly] delivery mode with a unique id for this fragment. In rare circumstances, if you
+     * make two identical subscriptions with the same (or all) properties in this fragment, provide a customId
+     * to avoid collisions.
+     *
+     * @param An additional custom id to identify this subscription. Only necessary if there are two subscriptions
+     * in this fragment with exact same properties (i.e. two subscribes, or two selectSubscribes with the same properties).
+     */
+    fun uniqueOnly(customId: String? = null) : UniqueOnly {
+        return UniqueOnly(listOfNotNull(mvrxViewId, customId).joinToString("_"))
+    }
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -26,8 +26,9 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
 
     /**
      * A globally unique id for this MvRxView. If your MvRxView is being recreated due to a lifecycle event (e.g. rotation)
-     * you should assign a consistent id. Likely this means you should save the id in onSaveInstance state. The
-     * viewId will not be accessed until a subscribe method is called.
+     * you should assign a consistent id. Likely this means you should save the id in onSaveInstance state.
+     * The viewId will not be accessed until a subscribe method is called. Accessing mvrxViewId before calling
+     * super.onCreate() will cause a crash.
      */
     val mvrxViewId: String
 
@@ -45,7 +46,7 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
     /**
      * Subscribes to all state updates for the given viewModel.
      *
-     * @param deliveryMode If [UniqueOnly], when this MvRxView goes from a stopped to start lifecycle a state value
+     * @param deliveryMode If [UniqueOnly] when this MvRxView goes from a stopped to started lifecycle a state value
      * will only be emitted if the state changed. This is useful for transient views that should only
      * be shown once (toasts, poptarts), or logging. Most other views should use false, as when a view is destroyed
      * and recreated the previous state is necessary to recreate the view.

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -636,7 +636,7 @@ class ViewModelSubscriberTest : BaseTest() {
         owner.lifecycle.markState(Lifecycle.State.STARTED)
 
         var callCount = 0
-        viewModel.subscribe(owner, uniqueOnly = true) {
+        viewModel.subscribe(owner, deliveryMode = UniqueOnly("id")) {
             callCount++
         }
 
@@ -654,7 +654,7 @@ class ViewModelSubscriberTest : BaseTest() {
         owner.lifecycle.markState(Lifecycle.State.STARTED)
 
         var callCount = 0
-        viewModel.subscribe(owner, uniqueOnly = true) {
+        viewModel.subscribe(owner, deliveryMode = UniqueOnly("id")) {
             callCount++
         }
 

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewSubscriberTest.kt
@@ -144,7 +144,7 @@ class ViewSubscriberTest : BaseTest() {
         assertEquals(2, fragment.selectSubscribeCallCount)
 
         assertEquals(0, fragment.selectSubscribeUniqueOnlyValue)
-        assertEquals(0, fragment.selectSubscribeUniqueOnlyCallCount)
+        assertEquals(1, fragment.selectSubscribeUniqueOnlyCallCount)
     }
 
     @Test

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewSubscriberTest.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.lang.IllegalStateException
 
 data class ViewSubscriberState(val foo: Int = 0) : MvRxState
 
@@ -320,5 +321,22 @@ class ViewSubscriberTest : BaseTest() {
         controller.resume()
 
         assertEquals(2, fragment.invalidateCallCount)
+    }
+
+    class DuplicateUniqueSubscriberFragment : BaseMvRxFragment() {
+        private val viewModel: ViewSubscriberViewModel by fragmentViewModel()
+
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            viewModel.subscribe(deliveryMode = uniqueOnly()) {  }
+            viewModel.subscribe(deliveryMode = uniqueOnly()) {  }
+        }
+
+        override fun invalidate() { }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun duplicateUniqueOnlySubscribeThrowIllegalStateException() {
+         createFragment<DuplicateUniqueSubscriberFragment, TestActivity>()
     }
 }


### PR DESCRIPTION
closes https://github.com/airbnb/MvRx/issues/204

Currently there is a bug where `uniqueOnly` will redeliver the last value, even if unchanged, during an orientation change. The intent of `uniqueOnly` was to emit a value only once, ever, to allow for actions that need to be taken only once, such as showing a PopTart or logging. (Just for posterity sake I want to note I recommend logging in ViewModel, as subscriptions there have a much simpler lifecycle).

In order to dedup a repeated value after a configuration change, the view model maintains a map between "subscriptionIds" and the last delivered value.

When you choose to subscribe with `uniqueOnly`, you must provide a subscription id, so the view model can perform the dedupping logic. An extension function `uniqueOnly()` on MvRxView will handle creating and persisting a unique subscription id across configuration changes.


@gpeal @elihart 