### PR TITLE
Fix saved state of editing TODO sample

### DIFF
--- a/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/AddEditTaskFragment.kt
+++ b/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/AddEditTaskFragment.kt
@@ -23,8 +23,11 @@ import android.support.design.widget.Snackbar
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.navigation.fragment.findNavController
+import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.args
+import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.todomvrx.core.BaseFragment
+import com.airbnb.mvrx.todomvrx.core.MvRxViewModel
 import com.airbnb.mvrx.todomvrx.data.Task
 import com.airbnb.mvrx.todomvrx.data.findTask
 import com.airbnb.mvrx.todomvrx.todoapp.R
@@ -39,37 +42,71 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class AddEditTaskArgs(val id: String? = null) : Parcelable
 
+data class EditTaskState(val newTitle: String? = null, val newDescription: String? = null) : MvRxState
+class EditTaskViewModel(initialState: EditTaskState) : MvRxViewModel<EditTaskState>(initialState) {
+    fun setTitle(title: String) {
+        setState { copy(newTitle = title) }
+    }
+
+    fun setDescription(description: String) {
+        setState { copy(newDescription = description) }
+    }
+}
+
 /**
  * Main UI for the add task screen. Users can enter a task title and description.
  */
 class AddEditTaskFragment : BaseFragment() {
+    private val taskViewModel: EditTaskViewModel by fragmentViewModel()
 
     private val args: AddEditTaskArgs by args()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Initialize fragment state if we are editing an existing task
+        withState(taskViewModel, viewModel) { thisTaskState, allTaskState ->
+            val task = allTaskState.tasks.findTask(args.id)
+
+            if (thisTaskState.newTitle == null) {
+                taskViewModel.setTitle(task?.title.orEmpty())
+            }
+
+            if (thisTaskState.newDescription == null) {
+                taskViewModel.setDescription(task?.description.orEmpty())
+            }
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         fab.setImageResource(R.drawable.ic_done)
         fab.setOnClickListener {
-            val (title, description) = recyclerView.asSequence().filterIsInstance(AddEditView::class.java).first().data()
+            withState(taskViewModel, viewModel) { thisTaskState, allTaskState ->
+                val newTitle = thisTaskState.newTitle
+                val newDescription = thisTaskState.newDescription
 
-            if (title.isEmpty()) {
-                Snackbar.make(coordinatorLayout, R.string.empty_task_message, Snackbar.LENGTH_LONG).show()
-                return@setOnClickListener
-            }
-            withState(viewModel) { state ->
-                val task = (state.tasks.findTask(args.id) ?: Task()).copy(title = title, description = description)
+                if (newTitle.isNullOrBlank()) {
+                    Snackbar.make(coordinatorLayout, R.string.empty_task_message, Snackbar.LENGTH_LONG).show()
+                    return@withState
+                }
+
+                val task = (allTaskState.tasks.findTask(args.id) ?: Task()).run {
+                    copy(title = newTitle, description = newDescription ?: description)
+                }
                 viewModel.upsertTask(task)
                 findNavController().navigateUp()
             }
         }
     }
 
-    override fun epoxyController() = simpleController(viewModel) { state ->
-        val task = state.tasks.findTask(args.id)
+    override fun epoxyController() = simpleController(taskViewModel) { state ->
         addEditView {
             id("add_edit")
-            title(task?.title)
-            description(task?.description)
+            title(state.newTitle)
+            description(state.newDescription)
+            onTitleChanged { taskViewModel.setTitle(it) }
+            onDescriptionChanged { taskViewModel.setDescription(it) }
         }
     }
 

--- a/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/core/BaseFragment.kt
+++ b/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/core/BaseFragment.kt
@@ -33,6 +33,11 @@ abstract class BaseFragment : BaseMvRxFragment() {
     // Used to keep track of task changes to determine if we should show a snackbar.
     private var oldTasks: Tasks? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        epoxyController.onRestoreInstanceState(savedInstanceState)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
         inflater.inflate(R.layout.fragment_base, container, false).apply {
             coordinatorLayout = findViewById(R.id.coordinator_layout)
@@ -40,6 +45,11 @@ abstract class BaseFragment : BaseMvRxFragment() {
             recyclerView = findViewById(R.id.recycler_view)
             recyclerView.setController(epoxyController)
         }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        epoxyController.onSaveInstanceState(outState)
+    }
 
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/views/AddEditView.kt
+++ b/todomvrx/src/main/java/com/airbnb/mvrx/todomvrx/views/AddEditView.kt
@@ -1,36 +1,115 @@
 package com.airbnb.mvrx.todomvrx.views
 
 import android.content.Context
+import android.text.Editable
+import android.text.Spanned
+import android.text.TextWatcher
 import android.util.AttributeSet
 import android.widget.EditText
 import android.widget.ScrollView
+import com.airbnb.epoxy.CallbackProp
 import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.TextProp
 import com.airbnb.mvrx.todomvrx.todoapp.R
 
+
 @ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_MATCH_HEIGHT)
 class AddEditView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
 ) : ScrollView(context, attrs, defStyleAttr) {
 
     private val titleView by lazy { findViewById<EditText>(R.id.task_title) }
     private val descriptionView by lazy { findViewById<EditText>(R.id.task_description) }
 
+    private val titleWatcher = SimpleTextWatcher { onTitleChanged?.invoke(it) }
+    private val descriptionWatcher = SimpleTextWatcher { onDescriptionChanged?.invoke(it) }
+
     init {
         inflate(context, R.layout.add_edit_view, this)
+        titleView.addTextChangedListener(titleWatcher)
+        descriptionView.addTextChangedListener(descriptionWatcher)
     }
 
     @TextProp
     fun setTitle(title: CharSequence?) {
-        titleView.setText(title)
+        titleView.setTextIfDifferent(title)
     }
 
     @TextProp
     fun setDescription(description: CharSequence?) {
-        descriptionView.setText(description)
+        descriptionView.setTextIfDifferent(description)
     }
 
-    fun data() = titleView.text.toString() to descriptionView.text.toString()
+    @set:CallbackProp
+    var onTitleChanged: ((newText: String) -> Unit)? = null
+
+    @set:CallbackProp
+    var onDescriptionChanged: ((newText: String) -> Unit)? = null
+
+}
+
+/**
+ * Set the given text on the textview.
+ *
+ * @return True if the given text is different from the previous text on the textview.
+ */
+fun EditText.setTextIfDifferent(newText: CharSequence?): Boolean {
+    if (!isTextDifferent(newText, text)) {
+        // Previous text is the same. No op
+        return false
+    }
+
+    setText(newText)
+    // Since the text changed we move the cursor to the end of the new text.
+    // This allows us to fill in text programmatically with a different value,
+    // but if the user is typing and the view is rebound we won't lose their cursor position.
+    setSelection(newText?.length ?: 0)
+    return true
+}
+
+/**
+ * @return True if str1 is different from str2.
+ *
+ *
+ * This is adapted from how the Android DataBinding library binds its text views.
+ */
+fun isTextDifferent(str1: CharSequence?, str2: CharSequence?): Boolean {
+    if (str1 === str2) {
+        return false
+    }
+    if (str1 == null || str2 == null) {
+        return true
+    }
+    val length = str1.length
+    if (length != str2.length) {
+        return true
+    }
+
+    if (str1 is Spanned) {
+        return str1 != str2
+    }
+
+    for (i in 0 until length) {
+        if (str1[i] != str2[i]) {
+            return true
+        }
+    }
+    return false
+}
+
+private class SimpleTextWatcher(val onTextChanged: (newText: String) -> Unit) : TextWatcher {
+    override fun afterTextChanged(s: Editable) {
+
+    }
+
+    override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+
+    }
+
+    override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+        onTextChanged(s.toString())
+    }
+
 }


### PR DESCRIPTION
Addresses https://github.com/airbnb/MvRx/issues/203

Epoxy state cannot be used as it clashes with the text we need to set from the view model - the best approach is to have a local fragment view model to store changed text.

This is a better pattern that getting text off of the recyclerview too, and also provides a good example for how to work with edit texts and epoxy.

@gpeal @BenSchwab 