### PR TITLE
[internal] Allow createViewModel to override stateFactory

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
@@ -5,8 +5,8 @@ import androidx.annotation.RestrictTo
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 interface MvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> {
 
-    fun createInitialState(viewModelClass: Class<VM>,
-                           stateClass: Class<S>,
+    fun createInitialState(viewModelClass: Class<out VM>,
+                           stateClass: Class<out S>,
                            viewModelContext: ViewModelContext,
                            stateRestorer: (S) -> S): S
 }
@@ -14,8 +14,8 @@ interface MvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> {
 internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : MvRxStateFactory<VM, S> {
 
     override fun createInitialState(
-        viewModelClass: Class<VM>,
-        stateClass: Class<S>,
+        viewModelClass: Class<out VM>,
+        stateClass: Class<out S>,
         viewModelContext: ViewModelContext,
         stateRestorer: (S) -> S
     ): S {
@@ -29,18 +29,17 @@ internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : 
  * Searches the companion of [viewModelClass] for an initialState function, and uses it to create the initial state.
  * If no such function exists, null is returned.
  */
+@Suppress("UNCHECKED_CAST")
 internal fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createStateFromCompanionFactory(
     viewModelClass: Class<out VM>,
     viewModelContext: ViewModelContext
 ): S? {
     return viewModelClass.factoryCompanion()?.let { factoryClass ->
         try {
-            @Suppress("UNCHECKED_CAST")
             factoryClass.getMethod("initialState", ViewModelContext::class.java)
                 .invoke(factoryClass.instance(), viewModelContext) as S?
         } catch (exception: NoSuchMethodException) {
             // Check for JvmStatic method.
-            @Suppress("UNCHECKED_CAST")
             viewModelClass.getMethod("initialState", ViewModelContext::class.java)
                 .invoke(null, viewModelContext) as S?
         }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
@@ -1,0 +1,81 @@
+package com.airbnb.mvrx
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+interface MvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> {
+
+    fun createInitialState(viewModelClass: Class<VM>,
+                           stateClass: Class<S>,
+                           viewModelContext: ViewModelContext,
+                           stateRestorer: (S) -> S): S
+}
+
+internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : MvRxStateFactory<VM, S> {
+
+    override fun createInitialState(
+        viewModelClass: Class<VM>,
+        stateClass: Class<S>,
+        viewModelContext: ViewModelContext,
+        stateRestorer: (S) -> S
+    ): S {
+        val factoryState = createStateFromCompanionFactory(viewModelClass, viewModelContext)
+        return stateRestorer(factoryState ?: createStateFromConstructor(viewModelClass, stateClass, viewModelContext.args))
+    }
+}
+
+/**
+ * Searches the companion of [viewModelClass] for an initialState function, and uses it to create the initial state.
+ * If no such function exists, null is returned.
+ */
+internal fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createStateFromCompanionFactory(
+    viewModelClass: Class<out VM>,
+    viewModelContext: ViewModelContext
+) : S? {
+    return viewModelClass.factoryCompanion()?.let { factoryClass ->
+        try {
+            @Suppress("UNCHECKED_CAST")
+            factoryClass.getMethod("initialState", ViewModelContext::class.java)
+                .invoke(factoryClass.instance(), viewModelContext) as S?
+        } catch (exception: NoSuchMethodException) {
+            // Check for JvmStatic method.
+            @Suppress("UNCHECKED_CAST")
+            viewModelClass.getMethod("initialState", ViewModelContext::class.java)
+                .invoke(null, viewModelContext) as S?
+        }
+    }
+}
+
+/**
+ * Searches [stateClass] for a single argument constructor matching the type of [args]. If [args] is null, then
+ * no arg constructor is invoked.
+ */
+internal fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createStateFromConstructor(
+    viewModelClass: Class<out VM>,
+    stateClass: Class<out S>,
+    args: Any?
+): S {
+    val argsConstructor = args?.let { arg ->
+        val argType = arg::class.java
+
+        stateClass.constructors.firstOrNull { constructor ->
+            constructor.parameterTypes.size == 1 && isAssignableTo(argType, constructor.parameterTypes[0])
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return argsConstructor?.newInstance(args) as? S
+        ?: try {
+            stateClass.newInstance()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+            null
+        }
+        ?: throw IllegalStateException(
+            "Attempt to create the MvRx state class ${stateClass.simpleName} has failed. One of the following must be true:" +
+                "\n 1) The state class has default values for every constructor property." +
+                "\n 2) The state class has a secondary constructor for ${args?.javaClass?.simpleName
+                    ?: "a fragment argument"}." +
+                "\n 3) ${viewModelClass.simpleName} must have a companion object implementing MvRxFactory with an initialState function " +
+                "that does not return null. "
+        )
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
@@ -20,7 +20,8 @@ internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : 
         stateRestorer: (S) -> S
     ): S {
         val factoryState = createStateFromCompanionFactory(viewModelClass, viewModelContext)
-        return stateRestorer(factoryState ?: createStateFromConstructor(viewModelClass, stateClass, viewModelContext.args))
+        return stateRestorer(factoryState
+            ?: createStateFromConstructor(viewModelClass, stateClass, viewModelContext.args))
     }
 }
 
@@ -31,7 +32,7 @@ internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : 
 internal fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createStateFromCompanionFactory(
     viewModelClass: Class<out VM>,
     viewModelContext: ViewModelContext
-) : S? {
+): S? {
     return viewModelClass.factoryCompanion()?.let { factoryClass ->
         try {
             @Suppress("UNCHECKED_CAST")
@@ -57,7 +58,6 @@ internal fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createStateFromConstruct
 ): S {
     val argsConstructor = args?.let { arg ->
         val argType = arg::class.java
-
         stateClass.constructors.firstOrNull { constructor ->
             constructor.parameterTypes.size == 1 && isAssignableTo(argType, constructor.parameterTypes[0])
         }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -24,8 +24,8 @@ object MvRxViewModelProvider {
      *            ViewModel class in the same scope.
      */
     fun <VM : BaseMvRxViewModel<S>, S : MvRxState> get(
-        viewModelClass: Class<VM>,
-        stateClass: Class<S>,
+        viewModelClass: Class<out VM>,
+        stateClass: Class<out S>,
         viewModelContext: ViewModelContext,
         key: String = viewModelClass.name,
         initialStateFactory: MvRxStateFactory<VM, S> = RealMvRxStateFactory()
@@ -40,8 +40,8 @@ object MvRxViewModelProvider {
 
     @Suppress("UNCHECKED_CAST")
     internal fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
-        viewModelClass: Class<VM>,
-        stateClass: Class<S>,
+        viewModelClass: Class<out VM>,
+        stateClass: Class<out S>,
         viewModelContext: ViewModelContext,
         stateRestorer: (S) -> S = { it },
         initialStateFactory: MvRxStateFactory<VM, S> = RealMvRxStateFactory()

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InitialConstructorStateTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InitialConstructorStateTest.kt
@@ -16,7 +16,7 @@ class InitialConstructorStateTest : BaseTest() {
     fun testParcelableArgs() {
         val args = ParcelableArgs("hello")
         val frag = Frag(args)
-        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestViewModel::class.java, TestState::class.java, frag._fragmentArgsProvider())
         assertEquals(args.str, state.str)
         assertEquals(null, state.num)
     }
@@ -25,7 +25,7 @@ class InitialConstructorStateTest : BaseTest() {
     fun testSerializableArgs() {
         val args = SerializableArgs(7)
         val frag = Frag(args)
-        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestViewModel::class.java, TestState::class.java, frag._fragmentArgsProvider())
         assertEquals(null, state.str)
         assertEquals(args.num, state.num)
     }
@@ -33,7 +33,7 @@ class InitialConstructorStateTest : BaseTest() {
     @Test
     fun testLongArgs() {
         val frag = Frag(8L)
-        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestViewModel::class.java, TestState::class.java, frag._fragmentArgsProvider())
         assertEquals("id", state.str)
         assertEquals(8, state.num)
     }
@@ -41,7 +41,7 @@ class InitialConstructorStateTest : BaseTest() {
     @Test
     fun testNoArgs() {
         val frag = Frag(null)
-        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestViewModel::class.java, TestState::class.java, frag._fragmentArgsProvider())
         assertEquals("empty", state.str)
         assertEquals(2, state.num)
     }
@@ -49,7 +49,7 @@ class InitialConstructorStateTest : BaseTest() {
     @Test
     fun testNoMatchingArgsFallsbackToEmptyConstructor() {
         val frag = Frag("unknown arg type")
-        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestViewModel::class.java, TestState::class.java, frag._fragmentArgsProvider())
         assertEquals("empty", state.str)
         assertEquals(2, state.num)
     }
@@ -82,6 +82,8 @@ data class TestState(
     constructor(id: Long) : this("id", id.toInt())
     constructor() : this("empty", 2)
 }
+
+private class TestViewModel(state: TestState) : BaseMvRxViewModel<TestState>(initialState = state, debugMode = false)
 
 @Parcelize
 class ParcelableArgs(val str: String) : Parcelable

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InitialConstructorStateTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InitialConstructorStateTest.kt
@@ -16,7 +16,7 @@ class InitialConstructorStateTest : BaseTest() {
     fun testParcelableArgs() {
         val args = ParcelableArgs("hello")
         val frag = Frag(args)
-        val state = MvRxViewModelProvider.createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
         assertEquals(args.str, state.str)
         assertEquals(null, state.num)
     }
@@ -25,7 +25,7 @@ class InitialConstructorStateTest : BaseTest() {
     fun testSerializableArgs() {
         val args = SerializableArgs(7)
         val frag = Frag(args)
-        val state = MvRxViewModelProvider.createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
         assertEquals(null, state.str)
         assertEquals(args.num, state.num)
     }
@@ -33,7 +33,7 @@ class InitialConstructorStateTest : BaseTest() {
     @Test
     fun testLongArgs() {
         val frag = Frag(8L)
-        val state = MvRxViewModelProvider.createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
         assertEquals("id", state.str)
         assertEquals(8, state.num)
     }
@@ -41,7 +41,7 @@ class InitialConstructorStateTest : BaseTest() {
     @Test
     fun testNoArgs() {
         val frag = Frag(null)
-        val state = MvRxViewModelProvider.createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
         assertEquals("empty", state.str)
         assertEquals(2, state.num)
     }
@@ -49,7 +49,7 @@ class InitialConstructorStateTest : BaseTest() {
     @Test
     fun testNoMatchingArgsFallsbackToEmptyConstructor() {
         val frag = Frag("unknown arg type")
-        val state = MvRxViewModelProvider.createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
+        val state = createStateFromConstructor(TestState::class.java, frag._fragmentArgsProvider())
         assertEquals("empty", state.str)
         assertEquals(2, state.num)
     }


### PR DESCRIPTION
In https://github.com/airbnb/MvRx/pull/169 we removed the ability to call `createViewModel` with a custom state factory. This seemed innocuous, but some internal test infrastructure at Airbnb requires the ability to override the state factory.

This PR has no functional change, and only moves functions marked Restrict to library or internal.

I do see some value in separating out a `MrRxStateFactory` interface, as we may be able to open source some of our test infra. Also it may make creating better dagger support easier.

@elihart @gpeal 