### PR TITLE
Allow Fail to be used with Exceptions with no stack trace

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -69,7 +69,7 @@ data class Fail<out T>(val error: Throwable) : Async<T>(complete = true, shouldL
         val otherError = other.error
         return error::class == otherError::class &&
             error.message == otherError.message &&
-            (error.stackTrace.size == otherError.stackTrace.size && (error.stackTrace.isEmpty() || error.stackTrace[0] == otherError.stackTrace[0]))
+            error.stackTrace.firstOrNull() == otherError.stackTrace.firstOrNull()
     }
 
     override fun hashCode(): Int = Arrays.hashCode(arrayOf(error::class, error.message, error.stackTrace[0]))

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -68,8 +68,8 @@ data class Fail<out T>(val error: Throwable) : Async<T>(complete = true, shouldL
 
         val otherError = other.error
         return error::class == otherError::class &&
-                error.message == otherError.message &&
-                error.stackTrace[0] == otherError.stackTrace[0]
+            error.message == otherError.message &&
+            (error.stackTrace.size == otherError.stackTrace.size && (error.stackTrace.isEmpty() || error.stackTrace[0] == otherError.stackTrace[0]))
     }
 
     override fun hashCode(): Int = Arrays.hashCode(arrayOf(error::class, error.message, error.stackTrace[0]))

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxStateFactory.kt
@@ -5,10 +5,12 @@ import androidx.annotation.RestrictTo
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 interface MvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> {
 
-    fun createInitialState(viewModelClass: Class<out VM>,
-                           stateClass: Class<out S>,
-                           viewModelContext: ViewModelContext,
-                           stateRestorer: (S) -> S): S
+    fun createInitialState(
+        viewModelClass: Class<out VM>,
+        stateClass: Class<out S>,
+        viewModelContext: ViewModelContext,
+        stateRestorer: (S) -> S
+    ): S
 }
 
 internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : MvRxStateFactory<VM, S> {
@@ -20,8 +22,10 @@ internal class RealMvRxStateFactory<VM : BaseMvRxViewModel<S>, S : MvRxState> : 
         stateRestorer: (S) -> S
     ): S {
         val factoryState = createStateFromCompanionFactory(viewModelClass, viewModelContext)
-        return stateRestorer(factoryState
-            ?: createStateFromConstructor(viewModelClass, stateClass, viewModelContext.args))
+        return stateRestorer(
+            factoryState
+                ?: createStateFromConstructor(viewModelClass, stateClass, viewModelContext.args)
+        )
     }
 }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -1,9 +1,9 @@
 package com.airbnb.mvrx
 
-import androidx.lifecycle.ViewModelProviders
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProviders
 import kotlin.reflect.full.primaryConstructor
 
 /**
@@ -84,7 +84,6 @@ object MvRxViewModelProvider {
         }
         return null
     }
-
 }
 
 /**

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/AsyncTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/AsyncTest.kt
@@ -1,9 +1,8 @@
 package com.airbnb.mvrx
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import com.airbnb.mvrx.Async.Companion.getMetadata
 import com.airbnb.mvrx.Async.Companion.setMetadata
+import org.junit.Assert.*
 import org.junit.Test
 
 class AsyncTest : BaseTest() {
@@ -35,5 +34,59 @@ class AsyncTest : BaseTest() {
 
         success.setMetadata("hi")
         assertEquals("hi", success.getMetadata())
+    }
+
+    @Test
+    fun testFailEqualsWithSameException() {
+        val fail1 = Fail<Int>(IllegalStateException("foo"))
+        val fail2 = Fail<Int>(IllegalStateException("foo").withStackTraceOf(fail1.error))
+        assertEquals(fail1, fail2)
+    }
+
+    @Test
+    fun testFailNotEqualsWithDifferentMessage() {
+        val fail1 = Fail<Int>(IllegalStateException("foo"))
+        val fail2 = Fail<Int>(IllegalStateException("foo2").withStackTraceOf(fail1.error))
+        assertNotEquals(fail1, fail2)
+    }
+
+    @Test
+    fun testFailNotEqualsWithDifferentClass() {
+        val fail1 = Fail<Int>(IllegalStateException("foo"))
+        val fail2 = Fail<Int>(IllegalArgumentException("foo").withStackTraceOf(fail1.error))
+        assertNotEquals(fail1, fail2)
+    }
+
+    @Test
+    fun testFailNotEqualsWithDifferentStackTrace() {
+        val fail1 = Fail<Int>(IllegalStateException("foo"))
+        val fail2 = Fail<Int>(IllegalStateException("foo"))
+        assertNotEquals(fail1, fail2)
+    }
+
+    @Test
+    fun testFailNotEqualsWhenOneHasNoStackTrace() {
+        val fail1 = Fail<Int>(IllegalStateException("foo").apply { stackTrace = emptyArray() })
+        val fail2 = Fail<Int>(IllegalStateException("foo"))
+        assertNotEquals(fail1, fail2)
+    }
+
+    @Test
+    fun testFailNotEqualsWhenOtherHasNoStackTrace() {
+        val fail1 = Fail<Int>(IllegalStateException("foo"))
+        val fail2 = Fail<Int>(IllegalStateException("foo").apply { stackTrace = emptyArray() })
+        assertNotEquals(fail1, fail2)
+    }
+
+    @Test
+    fun testFailEqualsWhenNeitherHasStackTrace() {
+        val fail1 = Fail<Int>(IllegalStateException("foo").apply { stackTrace = emptyArray() })
+        val fail2 = Fail<Int>(IllegalStateException("foo").apply { stackTrace = emptyArray() })
+        assertEquals(fail1, fail2)
+    }
+
+    private fun Throwable.withStackTraceOf(other: Throwable): Throwable {
+        stackTrace = other.stackTrace
+        return this
     }
 }


### PR DESCRIPTION
Coroutine CancellationException can have an empty stack trace.

Also fixed Detekt