### PR TITLE
Improve impure reducer error message

### DIFF
--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/PureReducerValidationTest.kt
@@ -1,13 +1,19 @@
 package com.airbnb.mvrx
 
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
+
 
 data class PureReducerValidationState(val count: Int = 0) : MvRxState
 data class StateWithPrivateVal(private val count: Int = 0) : MvRxState
 
 class PureReducerValidationTest : BaseTest() {
 
-    @Test(expected = IllegalArgumentException::class)
+    @get:Rule
+    var thrown = ExpectedException.none()!!
+
+    @Test
     fun impureReducerShouldFail() {
         class ImpureViewModel(initialState: PureReducerValidationState) : TestMvRxViewModel<PureReducerValidationState>(initialState) {
             private var count = 0
@@ -18,6 +24,8 @@ class PureReducerValidationTest : BaseTest() {
                 }
             }
         }
+        thrown.expect(IllegalArgumentException::class.java)
+        thrown.expectMessage("Impure reducer set on ImpureViewModel! count changed from 1 to 2. Ensure that your state properties properly implement hashCode.")
         ImpureViewModel(PureReducerValidationState()).impureReducer()
     }
 
@@ -44,7 +52,7 @@ class PureReducerValidationTest : BaseTest() {
         PureViewModel(StateWithPrivateVal()).pureReducer()
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun impureReducerWithPrivatePropShouldFail() {
         class ImpureViewModel(initialState: StateWithPrivateVal) : TestMvRxViewModel<StateWithPrivateVal>(initialState) {
             private var count = 0
@@ -55,6 +63,9 @@ class PureReducerValidationTest : BaseTest() {
                 }
             }
         }
+
+        thrown.expect(IllegalArgumentException::class.java)
+        thrown.expectMessage("Impure reducer set on ImpureViewModel! count changed from 1 to 2. Ensure that your state properties properly implement hashCode.")
         ImpureViewModel(StateWithPrivateVal()).impureReducer()
     }
 }


### PR DESCRIPTION
There was some logic in the impure reducer check to identify which property changed (#160), however I noticed this didn't actually work. The `isAccessible` filter fails for even public properties, potentially because the backing field is not accessible, or because it's doing some other sort of check related to java accessibility that doesn't apply for kotlin.

I believe the correct check in kotlin would be `it.visibility == KVisibility.PUBLIC`. However, it seems more helpful to detect even private properties. So this change makes the properties accessible, but catches any failures to get them.

I also added the view model name to the error message, since it isn't necessarily clear which viewmodel failed.

@gpeal @BenSchwab @hellohuanlin 

