### PR TITLE
fix: Make flushQueues() tailrecursive

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/RealMvRxStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/RealMvRxStateStore.kt
@@ -177,7 +177,7 @@ class RealMvRxStateStore<S : Any>(initialState: S) : MvRxStateStore<S> {
      * In case the setState queue calls setState, we call flushQueues recursively to flush the setState queue
      * in between every getState block gets processed.
      */
-    private fun flushQueues() {
+    private tailrec fun flushQueues() {
         flushSetStateQueue()
         val block = jobs.dequeueGetStateBlock() ?: return
         block(state)


### PR DESCRIPTION
The `flushQueues()` function in `RealMvRxStateStore` can be made tail recursive.

I have measured the performance of both state stores using a simple benchmark created with the AndroidX Benchmark library. You can checkout the code at the [benchmark branch](https://github.com/haroldadmin/MvRx/tree/benchmark) on my fork of MvRx.

### Test 1
This test does not involve any recursive call to `flushQueues()`, so the performance difference is minimal.

```kotlin
data class TestState(val count: Int = 0)

@Test
fun setStateTest() {
  benchmarkRule.measureRepeated {
    for (i in 1..1000) {
      stateStore.set { copy(count = i) }
    }
  }
}
```

Here are the results:

| Run # | RealMvRxStateStore | TailrecStateStore |
| ------- | --------------------------- | ---------------------- |
| 1 | 68,52,552 ns | 48,59,480 ns |
| 2 | 76,68,595 ns | 14,26,615 ns |
| 3 | 15,97,552 ns | 72,64,428 ns |
| 4 | 74,56,147 ns | 74,64,428 ns |
| 5 | 43,76,250 ns | 68,21,876 ns |

Average time of RealMvRxStateStore: 5590219.2 ns
Average time of TailrecStateStore = 5567365.2 ns
Difference = 22854 ns
Average improvement = (22854 / 5590219.2) * 100 = 0.4088 %

-------------------------------

### Test 2

This test involves a single recursive call to `flushQueues()`, and the performance gains are extreme. The non-tailrec implementation also suffered from crashes due to StackOverflow. I kept running the test until I could get 5 data points atleast. Here are the [stack traces of crashed attempts](https://gist.github.com/haroldadmin/d085abda59ab59da6dcdb92313a628c0) 

```kotlin
@Test 
fun simpleRecursiveCallTest() {
  benchmarkRule.measureRepeated {
    stateStore.get { state ->
      stateStore.set { copy(count = state.count + 1) }
    }
  }
}
```
| Run # | RealMvRxStateStore | TailrecStateStore |
| ------- | --------------------------- | ---------------------- |
| 1 | 2282 ns | 1189 ns |
| 2 | 2386 ns | 760 ns |
| 3 | StackOverflow error | 1183 ns |
| 4 | 2350 ns | 1267 ns |
| 5 | 1377 ns | 1297 ns |
| 6 | StackOverflow error | 2026 ns |
| 7 | 3477 ns | 1230 ns |

Average time of RealMvRxStateStore: 2374.4 ns (Counting successful runs only)
Average time of TailrecStateStore = 1278.857142857 ns
Difference = 22465.142857143 ns
Average improvement = **946 %**

------------------------------------

### Test 3

```kotlin
@Test
fun complexRecursiveCallTest() {
  benchmarkRule.measureRepeated {
  stateStore.get {
    stateStore.set {
      stateStore.set { copy(count = this.count + 1) }
      copy(count = this.count - 1)
    }
  }
  stateStore.get {
     // Just to flush the queues again
  }
}
```

| Run # | RealMvRxStateStore | TailrecStateStore |
| ------- | --------------------------- | ---------------------- |
| 1 | Stackoverflow | 3219 ns |
| 2 | Stackoverflow | 1893 ns |
| 3 | Stackoverflow | 1845 ns |
| 4 | Stackoverflow | 2520 ns |
| 5 | Stackoverflow | 1766 ns |

I could not get the test to run successfully using the regular state store. The tailrec version, however, ran just fine.

---------------------------------------------------------

The benchmarks were run on the OG Google Pixel running Android Q Beta 3.
There are some variations in performance, probably due to JIT optimization. I'm not sure though.