### PR TITLE
[WIP] Allow usage of fragmentViewModel and activityViewModel in custom views

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.appCompatVersion = '1.0.2'
     ext.recyclerViewVersion = '1.0.0'
     ext.lifecycleVersion = '2.0.0'
-    ext.robolectricVersion = '4.0.2'
+    ext.robolectricVersion = '4.3'
     ext.epoxyVersion = '3.2.0'
     ext.moshiVersion = '1.6.0'
     ext.koinVersion = '0.9.3'

--- a/detekt.yml
+++ b/detekt.yml
@@ -93,7 +93,7 @@ formatting:
   SpacingAroundRangeOperator:
     active: true
   StringTemplate:
-    active: true
+    active: false
 
 comments:
   active: true

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Memoize.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Memoize.kt
@@ -1,0 +1,24 @@
+package com.airbnb.mvrx
+
+import io.reactivex.disposables.Disposable
+
+class Memoize<T>(private val factory: (key: String) -> Pair<T, Disposable>) {
+    private var key: String? = null
+    private var value: T? = null
+    private var disposable: Disposable? = null
+
+    val isInitialized get() = value != null
+
+    @Synchronized
+    fun get(key: String): T {
+        val currentValue = value
+        if (this.key == key && currentValue != null && disposable?.isDisposed != true) return currentValue
+
+        disposable?.dispose()
+        this.key = key
+        val (value, disposable) = factory(key)
+        this.value = value
+        this.disposable = disposable
+        return value
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxExtensions.kt
@@ -70,6 +70,7 @@ inline fun <T, reified VM : BaseMvRxViewModel<S>, reified S : MvRxState> T.viewV
 
         val context = ViewViewModelContext(activity, fragment, fragment?._fragmentArgsProvider(), this, storeOwner, key)
         val viewModel = MvRxViewModelProvider.get(viewModelClass.java, S::class.java, context, key)
+        // TODO: we can unsubscribe from the main invalidate call but not any manual subscriptions if the key ever changes.
         viewModel to viewModel.subscribe(viewLifecycleOwner, subscriber = { postOnInvalidate() })
     }
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxInvalidator.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxInvalidator.kt
@@ -1,0 +1,27 @@
+package com.airbnb.mvrx
+
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.view.View
+import androidx.lifecycle.Lifecycle
+
+internal object MvRxInvalidator {
+    // Set of MvRxView or StatefulViews identity hash codes that have a pending invalidate.
+    private val pendingInvalidates = HashSet<Int>()
+    private val handler = Handler(Looper.getMainLooper(), Handler.Callback { message ->
+        val obj = message.obj
+        pendingInvalidates.remove(System.identityHashCode(obj))
+        when {
+            obj is MvRxView -> if (obj.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) obj.invalidate()
+            obj is StatefulView && obj is View -> if (obj.isAttachedToWindow()) obj.onInvalidate()
+        }
+        true
+    })
+
+    fun post(obj: Any) {
+        if (pendingInvalidates.add(System.identityHashCode(obj))) {
+            handler.sendMessage(Message.obtain(handler, System.identityHashCode(obj), obj))
+        }
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -1,20 +1,7 @@
 package com.airbnb.mvrx
 
-import android.os.Handler
-import android.os.Looper
-import android.os.Message
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import kotlin.reflect.KProperty1
-
-// Set of MvRxView identity hash codes that have a pending invalidate.
-private val pendingInvalidates = HashSet<Int>()
-private val handler = Handler(Looper.getMainLooper(), Handler.Callback { message ->
-    val view = message.obj as MvRxView
-    pendingInvalidates.remove(System.identityHashCode(view))
-    if (view.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) view.invalidate()
-    true
-})
 
 /**
  * Implement this in your MvRx capable Fragment.
@@ -57,9 +44,7 @@ interface MvRxView : MvRxViewModelStoreOwner, LifecycleOwner {
         get() = this
 
     fun postInvalidate() {
-        if (pendingInvalidates.add(System.identityHashCode(this@MvRxView))) {
-            handler.sendMessage(Message.obtain(handler, System.identityHashCode(this@MvRxView), this@MvRxView))
-        }
+        MvRxInvalidator.post(this)
     }
 
     /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelFactory.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx
 
 import android.app.Application
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -50,6 +51,11 @@ sealed class ViewModelContext {
     abstract val activity: FragmentActivity
 
     /**
+     * The ViewModel key used to uniquely identify it in the ViewModelStore.
+     */
+    abstract val key: String
+
+    /**
      * Convenience method to type [activity].
      */
     @Suppress("UNCHECKED_CAST")
@@ -80,7 +86,8 @@ sealed class ViewModelContext {
  */
 class ActivityViewModelContext(
     override val activity: FragmentActivity,
-    override val args: Any?
+    override val args: Any?,
+    override val key: String
 ) : ViewModelContext()
 
 /**
@@ -93,7 +100,8 @@ class FragmentViewModelContext(
     /**
      * The fragment owner of the ViewModel.
      */
-    val fragment: Fragment
+    val fragment: Fragment,
+    override val key: String
 ) : ViewModelContext() {
     /**
      * Convenience method to type [fragment].
@@ -101,3 +109,12 @@ class FragmentViewModelContext(
     @Suppress("UNCHECKED_CAST")
     fun <F : Fragment> fragment(): F = fragment as F
 }
+
+class ViewViewModelContext(
+    override val activity: FragmentActivity,
+    val fragment: Fragment?,
+    override val args: Any?,
+    val view: View,
+    internal val owner: MvRxViewModelStoreOwner,
+    override val key: String
+) : ViewModelContext()

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -3,6 +3,7 @@ package com.airbnb.mvrx
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import kotlin.reflect.full.primaryConstructor
 
@@ -35,6 +36,7 @@ object MvRxViewModelProvider {
         return when (viewModelContext) {
             is ActivityViewModelContext -> ViewModelProviders.of(viewModelContext.activity, factory)
             is FragmentViewModelContext -> ViewModelProviders.of(viewModelContext.fragment, factory)
+            is ViewViewModelContext -> ViewModelProvider(viewModelContext.owner.mvrxViewModelStore.viewViewModels.getStore(viewModelContext.view), factory)
         }.get(key, viewModelClass)
     }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelStore.kt
@@ -25,6 +25,7 @@ class MvRxViewModelStore(private val viewModelStore: ViewModelStore) {
     @Suppress("UNCHECKED_CAST")
     private val map: HashMap<String, ViewModel> by lazy { mMapMethod.get(viewModelStore)!! as HashMap<String, ViewModel> }
 
+    /** This is only used for an Activities ViewModelStore. */
     internal val viewViewModels = ViewViewModelStore()
 
     /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/StatefulView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/StatefulView.kt
@@ -1,0 +1,16 @@
+package com.airbnb.mvrx
+
+/**
+ * Implement this in a custom view to expose [fragmentViewModel] and [activityViewModel] in a custom view. Similar to usage in Fragments,
+ * this will create a view-lifecycle-aware subscription.
+ * For [fragmentViewModel], this will walk up the view hierarchy until it finds a View that is the root view for a Fragment.
+ * [StatefulView] uses [onInvalidate] instead of `invalidate()` because `invalidate()` is already a function on View. It is also
+ * not called [MvRxView] because the name was already taken.
+ */
+interface StatefulView {
+    fun postOnInvalidate() {
+        MvRxInvalidator.post(this)
+    }
+
+    fun onInvalidate()
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/StatefulView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/StatefulView.kt
@@ -1,5 +1,8 @@
 package com.airbnb.mvrx
 
+import android.view.View
+import io.reactivex.disposables.Disposable
+
 /**
  * Implement this in a custom view to expose [fragmentViewModel] and [activityViewModel] in a custom view. Similar to usage in Fragments,
  * this will create a view-lifecycle-aware subscription.
@@ -8,9 +11,19 @@ package com.airbnb.mvrx
  * not called [MvRxView] because the name was already taken.
  */
 interface StatefulView {
+    // TODO: remove posting invalidate.
     fun postOnInvalidate() {
         MvRxInvalidator.post(this)
     }
 
     fun onInvalidate()
+
+    /**
+     * TODO: Implement this
+     * TODO: Ensure this crashes if subscriptions happen outside of it.
+     */
+    fun setupSubscriptions(): List<Disposable> = emptyList()
+
+    fun <T> T.selectSubscribe() where T : View, T : StatefulView {
+    }
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/UninitializedValue.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/UninitializedValue.kt
@@ -1,0 +1,3 @@
+package com.airbnb.mvrx
+
+internal object UninitializedValue

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewLifecycleOwner.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewLifecycleOwner.kt
@@ -39,6 +39,8 @@ class ViewLifecycleOwner(private val view: View) : LifecycleOwner {
             }
         })
 
+        // TODO: handle Activity lifecycle to handle screen off and backgrounding
+
         // This causes Views to get invalidated twice when they are attached to the window
         // We call onInvalidate directly immediately to ensure that the correct data is rendered
         // in the first frame. However, invalidate will get posted again as the lifecycle

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewLifecycleOwner.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewLifecycleOwner.kt
@@ -1,0 +1,103 @@
+package com.airbnb.mvrx
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.OnLifecycleEvent
+
+class ViewLifecycleOwner(private val view: View) : LifecycleOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+
+    /**
+     * This is guaranteed to be a MvRxView.
+     */
+    private var _fragment: Fragment? = null
+    val fragment: Fragment?
+        get() {
+            // If a ViewModel is called from onAttachedToWindow, ths Fragment may be attached before the onAttachStateChangeListener is called.
+            if (_fragment == null && view.isAttachedToWindow) {
+                handleAttachedToWindow()
+            }
+            return _fragment
+        }
+    val activity get() = view.context as? AppCompatActivity
+
+    init {
+        view.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewDetachedFromWindow(v: View) {
+                lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+            }
+
+            override fun onViewAttachedToWindow(v: View) {
+                handleAttachedToWindow()
+            }
+        })
+
+        // This causes Views to get invalidated twice when they are attached to the window
+        // We call onInvalidate directly immediately to ensure that the correct data is rendered
+        // in the first frame. However, invalidate will get posted again as the lifecycle
+        // transitions to onResume.
+        lifecycleRegistry.addObserver(object : LifecycleObserver {
+            @OnLifecycleEvent(Lifecycle.Event.ON_START)
+            fun onStart() {
+                (view as? StatefulView)?.onInvalidate()
+            }
+        })
+
+        // TODO: pause and resume for visibility.
+    }
+
+    private fun handleAttachedToWindow() {
+        val lifecycleOwner = view.fragment()
+        this@ViewLifecycleOwner._fragment = lifecycleOwner
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    }
+
+    override fun getLifecycle() = lifecycleRegistry
+
+    fun View.fragment(): Fragment? {
+        _fragment?.let { previousFragment ->
+            if (!hasFragmentChanged(previousFragment)) return previousFragment
+        }
+
+        val activity = context as? AppCompatActivity
+        val viewFragmentMap = mutableMapOf<View, Fragment>()
+        activity?.supportFragmentManager?.fragments?.forEach { it.collectViewMap(viewFragmentMap) }
+
+        var view: View? = this
+        while (view != null) {
+            val fragment = viewFragmentMap[view]
+            if (fragment != null && fragment is MvRxView) {
+                this@ViewLifecycleOwner._fragment = fragment
+                return fragment
+            }
+            view = view.parent as? ViewGroup
+        }
+
+        return null
+    }
+
+    fun hasFragmentChanged(fragment: Fragment): Boolean {
+        fragment.view?.let { previousFragmentView ->
+            var view: View? = view
+            while (view != null) {
+                if (view == previousFragmentView) {
+                    return false
+                }
+                view = view.parent as? ViewGroup
+            }
+        }
+        return true
+    }
+
+    fun Fragment.collectViewMap(map: MutableMap<View, Fragment>) {
+        view?.let { view -> map[view] = this }
+        childFragmentManager.fragments.forEach { it.collectViewMap(map) }
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewViewModelStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewViewModelStore.kt
@@ -1,0 +1,94 @@
+package com.airbnb.mvrx
+
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.ViewModelStore
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.util.Timer
+import kotlin.concurrent.fixedRateTimer
+
+internal class ViewViewModelStore {
+
+    class ViewReference(
+        val view: View,
+        queue: ReferenceQueue<View>,
+        private val store: ViewModelStore
+    ) : WeakReference<View>(view, queue) {
+
+        fun cleanUp() {
+            store.clear()
+        }
+    }
+
+    private lateinit var activity: AppCompatActivity
+
+    private val referenceQueue = ReferenceQueue<View>()
+    private val viewMap = mutableMapOf<ViewReference, ViewModelStore>()
+    /** Helper to find the right key for [viewMap]. */
+    private val viewIdeneityRefMap = mutableMapOf<Int, ViewReference>()
+
+    private var timer: Timer? = null
+
+    fun getStore(view: View): ViewModelStore {
+        if (!this::activity.isInitialized) {
+            activity = view.context as AppCompatActivity
+        }
+
+        val identity = System.identityHashCode(view)
+        viewIdeneityRefMap[identity]?.let { ref ->
+            return viewMap[ref]!!
+        }
+
+        val store = ViewModelStore()
+        val ref = ViewReference(view, referenceQueue, store)
+        viewIdeneityRefMap[identity] = ref
+        viewMap[ref] = store
+        ensureTimer()
+        return store
+    }
+
+    private fun registerLifecycle() {
+        activity.lifecycle.addObserver(object : LifecycleObserver {
+            @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+            fun onDestroy() {
+                stopTimer()
+                viewMap.values.forEach { it.clear() }
+                viewMap.clear()
+                viewIdeneityRefMap.clear()
+            }
+        })
+    }
+
+    private fun ensureTimer() {
+        if (timer != null) {
+            return
+        }
+        fixedRateTimer(
+            name = "expunge_dereferenced_views",
+            initialDelay = 60_000,
+            period = 60_000
+        ) {
+            var ref = referenceQueue.poll() as ViewReference?
+            while (ref != null) {
+                Log.d("Gabe", "Pruning: $ref")
+                viewMap.remove(ref)
+                viewIdeneityRefMap.remove(System.identityHashCode(ref.view))
+                ref.cleanUp()
+                ref = referenceQueue.poll() as ViewReference?
+            }
+            if (viewMap.isEmpty()) {
+                stopTimer()
+            }
+        }
+    }
+
+    private fun stopTimer() {
+        timer?.cancel()
+        timer = null
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewViewModelStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewViewModelStore.kt
@@ -15,10 +15,11 @@ import kotlin.concurrent.fixedRateTimer
 internal class ViewViewModelStore {
 
     class ViewReference(
-        val view: View,
+        view: View,
         queue: ReferenceQueue<View>,
         private val store: ViewModelStore
     ) : WeakReference<View>(view, queue) {
+        val viewIdentity = System.identityHashCode(view)
 
         fun cleanUp() {
             store.clear()
@@ -77,7 +78,7 @@ internal class ViewViewModelStore {
             while (ref != null) {
                 Log.d("Gabe", "Pruning: $ref")
                 viewMap.remove(ref)
-                viewIdeneityRefMap.remove(System.identityHashCode(ref.view))
+                viewIdeneityRefMap.remove(ref.viewIdentity)
                 ref.cleanUp()
                 ref = referenceQueue.poll() as ViewReference?
             }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
@@ -2,33 +2,31 @@
 
 package com.airbnb.mvrx
 
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
-import androidx.annotation.RestrictTo
+import io.reactivex.disposables.Disposable
 import java.io.Serializable
-
-private object UninitializedValue
 
 /**
  * This was copied from SynchronizedLazyImpl but modified to automatically initialize in ON_CREATE.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 @SuppressWarnings("Detekt.ClassNaming")
-class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: () -> T) : Lazy<T>, Serializable {
-    private var initializer: (() -> T)? = initializer
-    @Volatile
+class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, private val keyFactory: () -> String, initializer: (key: String) -> Pair<T, Disposable>) : Lazy<T>,
+    Serializable {
     @SuppressWarnings("Detekt.VariableNaming")
-    private var _value: Any? = UninitializedValue
+    private val _value = Memoize<T>(initializer)
     // final field is required to enable safe publication of constructed instance
     private val lock = this
 
     init {
         owner.lifecycle.addObserver(object : LifecycleObserver {
             @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-            fun onStart() {
-                if (!isInitialized()) value
+            fun onCreate() {
+                value
                 owner.lifecycle.removeObserver(this)
             }
         })
@@ -36,29 +34,9 @@ class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: 
 
     @Suppress("LocalVariableName")
     override val value: T
-        get() {
-            @SuppressWarnings("Detekt.VariableNaming")
-            val _v1 = _value
-            if (_v1 !== UninitializedValue) {
-                @Suppress("UNCHECKED_CAST")
-                return _v1 as T
-            }
-
-            return synchronized(lock) {
-                @SuppressWarnings("Detekt.VariableNaming")
-                val _v2 = _value
-                if (_v2 !== UninitializedValue) {
-                    @Suppress("UNCHECKED_CAST") (_v2 as T)
-                } else {
-                    val typedValue = initializer!!()
-                    _value = typedValue
-                    initializer = null
-                    typedValue
-                }
-            }
+        get() = synchronized(lock) {
+            _value.get(keyFactory())
         }
 
-    override fun isInitialized(): Boolean = _value !== UninitializedValue
-
-    override fun toString(): String = if (isInitialized()) value.toString() else "Lazy value not initialized yet."
+    override fun isInitialized() = _value.isInitialized
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
@@ -43,7 +43,7 @@ class NoFactoryTest : BaseTest() {
     fun createFromActivityOwner() {
         class MyViewModel(initialState: FactoryState) : TestMvRxViewModel<FactoryState>(initialState)
 
-        val viewModel = MvRxViewModelProvider.get(MyViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(MyViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -54,7 +54,7 @@ class NoFactoryTest : BaseTest() {
         val (_, fragment) = createFragment<ViewModelFactoryTestFragment, TestActivity>()
         class MyViewModel(initialState: FactoryState) : TestMvRxViewModel<FactoryState>(initialState)
 
-        val viewModel = MvRxViewModelProvider.get(MyViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment))
+        val viewModel = MvRxViewModelProvider.get(MyViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment, "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -62,7 +62,7 @@ class NoFactoryTest : BaseTest() {
 
     @Test
     fun createWithNonFactoryCompanion() {
-        val viewModel = MvRxViewModelProvider.get(MyViewModelWithNonFactoryCompanion::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(MyViewModelWithNonFactoryCompanion::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -75,31 +75,31 @@ class NoFactoryTest : BaseTest() {
         class MyViewModel(initialState: PrivateState) : TestMvRxViewModel<PrivateState>(initialState)
         // Create a view model to run state validation checks.
         @Suppress("UNUSED_VARIABLE")
-        val viewModel = MvRxViewModelProvider.get(MyViewModel::class.java, PrivateState::class.java, ActivityViewModelContext(activity, null))
+        val viewModel = MvRxViewModelProvider.get(MyViewModel::class.java, PrivateState::class.java, ActivityViewModelContext(activity, null, "hello"))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun failOnDefaultState() {
         class MyViewModel(initialState: FactoryState = FactoryState()) : TestMvRxViewModel<FactoryState>(initialState)
-        MvRxViewModelProvider.get(MyViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null))
+        MvRxViewModelProvider.get(MyViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null, "hello"))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun failOnWrongSingleParameterType() {
         class ViewModel : BaseMvRxViewModel<FactoryState>(initialState = FactoryState(), debugMode = false)
-        MvRxViewModelProvider.get(ViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null))
+        MvRxViewModelProvider.get(ViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null, "hello"))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun failOnMultipleParametersAndNoCompanion() {
         class OptionalParamViewModel(initialState: FactoryState, debugMode: Boolean = false) : BaseMvRxViewModel<FactoryState>(initialState, debugMode)
-        MvRxViewModelProvider.get(OptionalParamViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null))
+        MvRxViewModelProvider.get(OptionalParamViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null, "hello"))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun failOnNoViewModelParameters() {
         class OptionalParamViewModel : BaseMvRxViewModel<FactoryState>(initialState = FactoryState(), debugMode = false)
-        MvRxViewModelProvider.get(OptionalParamViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null))
+        MvRxViewModelProvider.get(OptionalParamViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, null, "hello"))
     }
 }
 
@@ -153,7 +153,7 @@ class FactoryViewModelTest : BaseTest() {
 
     @Test
     fun createFromActivityOwner() {
-        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -164,7 +164,7 @@ class FactoryViewModelTest : BaseTest() {
     fun createFromFragmentOwner() {
         val (_, fragment) = createFragment<ViewModelFactoryTestFragment, TestActivity>()
         fragment.arguments = Bundle().apply { putLong("otherProp", 6L) }
-        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment, "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -173,7 +173,7 @@ class FactoryViewModelTest : BaseTest() {
 
     @Test
     fun createWithJvmStatic() {
-        val viewModel = MvRxViewModelProvider.get(TestFactoryJvmStaticViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryJvmStaticViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -182,7 +182,7 @@ class FactoryViewModelTest : BaseTest() {
 
     @Test
     fun nullInitialStateDelegatesToConstructor() {
-        val viewModel = MvRxViewModelProvider.get(TestNullFactory::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestNullFactory::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -190,7 +190,7 @@ class FactoryViewModelTest : BaseTest() {
 
     @Test
     fun testApplicationCanBeAccessed() {
-        MvRxViewModelProvider.get(ViewModelContextApplicationFactory::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        MvRxViewModelProvider.get(ViewModelContextApplicationFactory::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
     }
 }
 
@@ -232,7 +232,7 @@ class FactoryStateTest : BaseTest() {
 
     @Test
     fun createFromActivityOwner() {
-        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello factory"), state)
         }
@@ -242,7 +242,7 @@ class FactoryStateTest : BaseTest() {
     fun createFromFragmentOwner() {
         val (_, fragment) = createFragment<ViewModelFactoryTestFragment, TestActivity>()
         fragment.arguments = Bundle().apply { putString("greeting", "howdy") }
-        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment, "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("howdy and hello factory"), state)
         }
@@ -250,7 +250,7 @@ class FactoryStateTest : BaseTest() {
 
     @Test
     fun createWithJvmStatic() {
-        val viewModel = MvRxViewModelProvider.get(TestFactoryJvmStaticViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryJvmStaticViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello factory"), state)
         }
@@ -258,7 +258,7 @@ class FactoryStateTest : BaseTest() {
 
     @Test
     fun nullInitialStateDelegatesToConstructor() {
-        val viewModel = MvRxViewModelProvider.get(TestNullFactory::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestNullFactory::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello constructor"), state)
         }
@@ -292,7 +292,7 @@ class FactoryViewModelAndStateTest : BaseTest() {
 
     @Test
     fun createFromActivityOwner() {
-        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello factory"), state)
         }
@@ -303,7 +303,7 @@ class FactoryViewModelAndStateTest : BaseTest() {
     fun createFromFragmentOwner() {
         val (_, fragment) = createFragment<ViewModelFactoryTestFragment, TestActivity>()
 
-        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryViewModel::class.java, FactoryState::class.java, FragmentViewModelContext(activity, TestArgs("hello"), fragment, "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello factory"), state)
         }
@@ -312,7 +312,7 @@ class FactoryViewModelAndStateTest : BaseTest() {
 
     @Test
     fun createWithJvmStatic() {
-        val viewModel = MvRxViewModelProvider.get(TestFactoryJvmStaticViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        val viewModel = MvRxViewModelProvider.get(TestFactoryJvmStaticViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello"), "hello"))
         withState(viewModel) { state ->
             assertEquals(FactoryState("hello factory"), state)
         }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InitialStateTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InitialStateTest.kt
@@ -15,7 +15,7 @@ class InitialStateTest : BaseTest() {
         MvRxViewModelProvider.get(
             DefaultParamViewModel::class.java,
             DefaultParamState::class.java,
-            FragmentViewModelContext(controller.get(), null, fragment), "foo"
+            FragmentViewModelContext(controller.get(), null, fragment, "foo"), "foo"
         )
     }
 
@@ -26,7 +26,7 @@ class InitialStateTest : BaseTest() {
         MvRxViewModelProvider.get(
             NonDefaultParamViewModel::class.java,
             DefaultParamState::class.java,
-            FragmentViewModelContext(controller.get(), null, fragment), "foo"
+            FragmentViewModelContext(controller.get(), null, fragment, "foo"), "foo"
         )
     }
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/LifecycleAwareLazyTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/LifecycleAwareLazyTest.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx
 
 import androidx.lifecycle.Lifecycle
+import io.reactivex.internal.disposables.EmptyDisposable
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -14,7 +15,7 @@ class LifecycleAwareLazyTest : BaseTest() {
     @Before
     fun setup() {
         owner = TestLifecycleOwner()
-        lazyProp = lifecycleAwareLazy(owner) { "Hello World" }
+        lazyProp = lifecycleAwareLazy(owner, {"" }) { "Hello World" to EmptyDisposable.INSTANCE }
     }
 
     @Test
@@ -33,7 +34,7 @@ class LifecycleAwareLazyTest : BaseTest() {
     @Test
     fun testInitializedIfAlreadyStarted() {
         owner.lifecycle.markState(Lifecycle.State.STARTED)
-        lazyProp = lifecycleAwareLazy(owner) { "Hello World" }
+        lazyProp = lifecycleAwareLazy(owner, { "" }) { "Hello World" to EmptyDisposable.INSTANCE }
         assertTrue(lazyProp.isInitialized())
     }
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/MemoizeTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/MemoizeTest.kt
@@ -1,0 +1,63 @@
+package com.airbnb.mvrx
+
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
+import io.reactivex.internal.disposables.EmptyDisposable
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class MemoizeTest {
+    class NonDataClass(val text: String) : Disposable {
+        private var isDisposed = false
+
+        override fun isDisposed() = isDisposed
+        override fun dispose() {
+            isDisposed = true
+        }
+    }
+
+    val factory: (String) -> Pair<NonDataClass, Disposable> = { key ->
+        val ret = NonDataClass(key)
+        ret to ret
+    }
+
+    lateinit var memoize: Memoize<NonDataClass>
+
+
+    @Before
+    fun setup() {
+        memoize = Memoize<NonDataClass>(factory)
+    }
+
+    @Test
+    fun testGetsFirstObject() {
+        val firstFoo = memoize.get("foo")
+        val secondFoo = memoize.get("foo")
+        assertEquals("foo", firstFoo.text)
+        assertEquals(System.identityHashCode(firstFoo), System.identityHashCode(secondFoo))
+    }
+
+    @Test
+    fun testNewObjectReplacesFirst() {
+        memoize.get("foo")
+        val bar = memoize.get("bar")
+        assertEquals("bar", bar.text)
+    }
+
+    @Test
+    fun testDoesntCacheOriginal() {
+        val firstFoo = memoize.get("foo")
+        memoize.get("bar")
+        val secondFoo = memoize.get("foo")
+        assertNotEquals(firstFoo, secondFoo)
+    }
+
+    @Test
+    fun testNewObjectDisposesFirst() {
+        val foo = memoize.get("foo")
+        val bar = memoize.get("bar")
+        assertTrue(foo.isDisposed)
+        assertFalse(bar.isDisposed)
+    }
+}

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewViewModelTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ViewViewModelTest.kt
@@ -1,0 +1,138 @@
+package com.airbnb.mvrx
+
+import android.content.Context
+import android.os.Bundle
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.TextView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.robolectric.Robolectric
+import org.robolectric.shadows.ShadowLooper
+import java.util.concurrent.Semaphore
+import kotlin.properties.Delegates
+
+
+class ViewViewModelTest : BaseTest() {
+
+    data class ViewState(val title: String) : MvRxState
+    class ViewViewModel(state: ViewState) : TestMvRxViewModel<ViewState>(state) {
+
+        fun setTitle(title: String) = setState { copy(title = title) }
+
+        companion object : MvRxViewModelFactory<ViewViewModel, ViewState> {
+            override fun initialState(viewModelContext: ViewModelContext): ViewState? {
+                return ViewState(title = "Key: ${viewModelContext.key}")
+            }
+        }
+    }
+
+    class TitleView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
+    ) : TextView(context, attrs, defStyleAttr), StatefulView {
+        val viewModel: ViewViewModel by viewViewModel(keyFactory = { key })
+        var invalidateCount = 0
+        var key by Delegates.observable("key_0") { _, _, _ -> postInvalidate() }
+
+        override fun onInvalidate() = withState(viewModel) { state ->
+            invalidateCount++
+            text = state.title
+        }
+    }
+
+    class ViewFragment : BaseMvRxFragment() {
+
+        lateinit var titleView: TitleView
+
+        override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+            titleView = TitleView(requireContext())
+            return FrameLayout(requireContext()).apply { addView(titleView) }
+        }
+
+        override fun invalidate() {
+
+        }
+    }
+
+    @Test
+    fun testBasicViewViewModel() {
+        val (_, fragment) = createFragment<ViewFragment, TestActivity>(containerId = CONTAINER_ID)
+        assertEquals("Key: key_0", fragment.titleView.text)
+    }
+
+    @Test
+    fun testCanChangeKeys() {
+        val (_, fragment) = createFragment<ViewFragment, TestActivity>(containerId = CONTAINER_ID)
+        val firstViewModel = fragment.titleView.viewModel
+        assertEquals(2, fragment.titleView.invalidateCount)
+        fragment.titleView.key = "key_1"
+        assertEquals(4, fragment.titleView.invalidateCount)
+        assertEquals("Key: key_1", fragment.titleView.text)
+        val secondViewModel = fragment.titleView.viewModel
+        assertNotEquals(firstViewModel, secondViewModel)
+    }
+
+    @Test
+    fun testOnlySubscribesToNewViewModelWhenKeyChanges() {
+        val (_, fragment) = createFragment<ViewFragment, TestActivity>(containerId = CONTAINER_ID)
+        val firstViewModel = fragment.titleView.viewModel
+        assertEquals(2, fragment.titleView.invalidateCount)
+        fragment.titleView.key = "key_1"
+        val secondViewModel = fragment.titleView.viewModel
+
+        // Ensure the UI updates when the key changes.
+        assertEquals("Key: key_1", fragment.titleView.text)
+        assertEquals(4, fragment.titleView.invalidateCount)
+
+        firstViewModel.setTitle("Update Original ViewModel")
+        assertEquals(4, fragment.titleView.invalidateCount)
+
+        secondViewModel.setTitle("Update New ViewModel")
+        assertEquals(5, fragment.titleView.invalidateCount)
+    }
+
+    @Test
+    fun testInvalidatesAtTheRightTime() {
+        val (_, fragment) = createFragment<ViewFragment, TestActivity>(containerId = CONTAINER_ID)
+        assertEquals(2, fragment.titleView.invalidateCount)
+        (fragment.view as ViewGroup).removeView(fragment.titleView)
+        fragment.titleView.viewModel.setTitle("Update 1")
+        fragment.titleView.viewModel.setTitle("Update 2")
+        assertEquals(2, fragment.titleView.invalidateCount)
+        (fragment.view as ViewGroup).addView(fragment.titleView)
+        assertEquals(4, fragment.titleView.invalidateCount)
+        fragment.titleView.viewModel.setTitle("Update 3")
+        assertEquals(5, fragment.titleView.invalidateCount)
+
+    }
+
+    @Test
+    fun testUpdatesWithState() {
+        val (_, fragment) = createFragment<ViewFragment, TestActivity>(containerId = CONTAINER_ID)
+        assertEquals(2, fragment.titleView.invalidateCount)
+        fragment.titleView.viewModel.setTitle("Update!")
+        assertEquals("Update!", fragment.titleView.text)
+        assertEquals(3, fragment.titleView.invalidateCount)
+        fragment.titleView.viewModel.setTitle("Update2!")
+        assertEquals("Update2!", fragment.titleView.text)
+        assertEquals(4, fragment.titleView.invalidateCount)
+    }
+
+    @Test
+    fun testOnlyInvalidesOnceWhenSwitchingViewModelKeys() {
+        val (controller, fragment) = createFragment<ViewFragment, TestActivity>(containerId = CONTAINER_ID)
+        assertEquals(2, fragment.titleView.invalidateCount)
+        fragment.titleView.key = "key_1"
+        val semaphore = Semaphore(0)
+        controller.get().runOnUiThread { semaphore.release() }
+        semaphore.acquire()
+        assertEquals("Key: key_1", fragment.titleView.text)
+        assertEquals(3, fragment.titleView.invalidateCount)
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/MainFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/MainFragment.kt
@@ -29,6 +29,13 @@ class MainFragment : BaseFragment() {
         }
 
         basicRow {
+            id("stateful_view")
+            title("Custom Stateful Views")
+            subtitle(demonstrates("StatefulView", "Custom Views"))
+            clickListener { _ -> navigateTo(R.id.action_main_to_statefulViewFragment) }
+        }
+
+        basicRow {
             id("random_dad_joke")
             title("Random Dad Joke")
             subtitle(demonstrates("fragmentViewModel", "Network requests", "Dependency Injection"))

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/ActivityCounterView.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/ActivityCounterView.kt
@@ -1,0 +1,23 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.widget.TextView
+import com.airbnb.mvrx.StatefulView
+import com.airbnb.mvrx.activityViewModel
+import com.airbnb.mvrx.withState
+
+class ActivityCounterView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : TextView(context, attrs, defStyleAttr), StatefulView {
+
+    private val viewModel: CounterViewModel by activityViewModel()
+
+    override fun onInvalidate() = withState(viewModel) { state ->
+        Log.d("Gabe", "onInvalidate: ActivityCounterView")
+        text = "Activity Count: ${state.count}"
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/AttachCountView.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/AttachCountView.kt
@@ -1,0 +1,35 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.TextView
+import com.airbnb.mvrx.MvRxState
+import com.airbnb.mvrx.StatefulView
+import com.airbnb.mvrx.activityViewModel
+import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.sample.core.MvRxViewModel
+import com.airbnb.mvrx.withState
+
+data class AttachCountState(val attachCount: Int = 0) : MvRxState
+class AttachCountViewModel(state: AttachCountState) : MvRxViewModel<AttachCountState>(state) {
+    fun incrementAttachCount() = setState { copy(attachCount = attachCount + 1) }
+}
+
+class AttachCountView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : TextView(context, attrs, defStyleAttr), StatefulView {
+
+    private val viewModel: AttachCountViewModel by fragmentViewModel()
+    private val activityCounterViewModel: CounterViewModel by activityViewModel()
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        viewModel.incrementAttachCount()
+    }
+
+    override fun onInvalidate() = withState(viewModel, activityCounterViewModel) { state, counterState ->
+        text = "Attach Count: ${state.attachCount}\nActivity Count: ${counterState.count}"
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/CounterViewModel.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/CounterViewModel.kt
@@ -1,0 +1,12 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import com.airbnb.mvrx.MvRxState
+import com.airbnb.mvrx.PersistState
+import com.airbnb.mvrx.sample.core.MvRxViewModel
+
+data class CounterState(@PersistState val count: Int = 0) : MvRxState
+
+class CounterViewModel(state: CounterState) : MvRxViewModel<CounterState>(state) {
+
+    fun incrementCount() = setState { copy(count = count + 1) }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/FragmentCounterView.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/FragmentCounterView.kt
@@ -1,0 +1,21 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.TextView
+import com.airbnb.mvrx.StatefulView
+import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.withState
+
+class FragmentCounterView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : TextView(context, attrs, defStyleAttr), StatefulView {
+
+    private val viewModel: CounterViewModel by fragmentViewModel()
+
+    override fun onInvalidate() = withState(viewModel) { state ->
+        text = "Fragment Count: ${state.count}"
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/StatefulBasicRow.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/StatefulBasicRow.kt
@@ -1,0 +1,49 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.airbnb.epoxy.CallbackProp
+import com.airbnb.epoxy.ModelView
+import com.airbnb.epoxy.TextProp
+import com.airbnb.mvrx.StatefulView
+import com.airbnb.mvrx.activityViewModel
+import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.sample.R
+import com.airbnb.mvrx.withState
+
+@ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_WRAP_HEIGHT)
+class StatefulBasicRow @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr), StatefulView {
+
+    private val fragmentScopedViewModel: StatefulViewViewModel by fragmentViewModel()
+    private val activityScopedViewModel: StatefulViewViewModel by activityViewModel()
+
+    private val titleView: TextView
+    private val subtitleView: TextView
+
+    init {
+        inflate(context, R.layout.basic_row, this)
+        titleView = findViewById(R.id.title)
+        subtitleView = findViewById(R.id.subtitle)
+        orientation = VERTICAL
+    }
+
+    @TextProp
+    fun setTitle(title: CharSequence) {
+        titleView.text = title
+    }
+
+    @CallbackProp
+    fun setClickListener(clickListener: OnClickListener?) {
+        setOnClickListener(clickListener)
+    }
+
+    override fun onInvalidate() = withState(fragmentScopedViewModel, activityScopedViewModel) { fragmentState, activityState ->
+        subtitleView.text = "${fragmentState.title}\n${activityState.title}"
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/StatefulViewFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/StatefulViewFragment.kt
@@ -1,0 +1,51 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.setupWithNavController
+import com.airbnb.mvrx.BaseMvRxFragment
+import com.airbnb.mvrx.activityViewModel
+import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.sample.R
+
+class StatefulViewFragment : BaseMvRxFragment() {
+    private val fragmentScopedViewModel: CounterViewModel by fragmentViewModel()
+    private val activityScopedViewModel: CounterViewModel by activityViewModel()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_stateful_view, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        view.findViewById<Toolbar>(R.id.toolbar).setupWithNavController(findNavController())
+        view.findViewById<View>(R.id.navigate).setOnClickListener {
+            findNavController().navigate(R.id.action_statefulViewFragment_self)
+        }
+
+        view.findViewById<View>(R.id.increment_fragment).setOnClickListener {
+            fragmentScopedViewModel.incrementCount()
+        }
+
+        view.findViewById<View>(R.id.increment_activity).setOnClickListener {
+            activityScopedViewModel.incrementCount()
+        }
+
+        val toggledView = view.findViewById<View>(R.id.attach_count)
+        val toggledViewParent = toggledView.parent as ViewGroup
+        view.findViewById<View>(R.id.toggle_view).setOnClickListener {
+            if (toggledView.isAttachedToWindow) {
+                toggledViewParent.removeView(toggledView)
+            } else {
+                toggledViewParent.addView(toggledView)
+            }
+        }
+    }
+
+    override fun invalidate() {
+        // Do nothing.
+    }
+}

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/StatefulViewViewModel.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/statefulview/StatefulViewViewModel.kt
@@ -1,0 +1,10 @@
+package com.airbnb.mvrx.sample.features.statefulview
+
+import com.airbnb.mvrx.MvRxState
+import com.airbnb.mvrx.sample.core.MvRxViewModel
+
+data class StatefulViewState(val title: String = "Hello World") : MvRxState
+
+class StatefulViewViewModel(state: StatefulViewState) : MvRxViewModel<StatefulViewState>(state) {
+    fun setTitle(title: String) = setState { copy(title = title) }
+}

--- a/sample/src/main/res/layout/fragment_stateful_view.xml
+++ b/sample/src/main/res/layout/fragment_stateful_view.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <Button
+        android:id="@+id/increment_fragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Increment"
+        app:layout_constraintBottom_toBottomOf="@id/fragment_counter_view"
+        app:layout_constraintEnd_toStartOf="@+id/fragment_counter_view"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/fragment_counter_view" />
+
+    <Button
+        android:id="@+id/increment_activity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Increment"
+        app:layout_constraintBottom_toBottomOf="@id/activity_counter_view"
+        app:layout_constraintEnd_toStartOf="@+id/activity_counter_view"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/activity_counter_view" />
+
+    <Button
+        android:id="@+id/navigate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="Navigate"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/activity_counter_view" />
+
+    <Button
+        android:id="@+id/toggle_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Toggle View"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/attach_count"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.25" />
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_arrow_back" />
+
+    <com.airbnb.mvrx.sample.features.statefulview.ActivityCounterView
+        android:id="@+id/activity_counter_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="32dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/increment_activity"
+        app:layout_constraintTop_toBottomOf="@id/fragment_counter_view"
+        tools:text="Count: 10" />
+
+    <com.airbnb.mvrx.sample.features.statefulview.AttachCountView
+        android:id="@+id/attach_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/toggle_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/toggle_view"
+        app:layout_constraintTop_toTopOf="@+id/toggle_view"
+        tools:text="Attach Count: 1" />
+
+    <com.airbnb.mvrx.sample.features.statefulview.FragmentCounterView
+        android:id="@+id/fragment_counter_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/increment_fragment"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Count: 10" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/navigation/nav_graph.xml
+++ b/sample/src/main/res/navigation/nav_graph.xml
@@ -40,6 +40,13 @@
             app:exitAnim="@anim/anim_exit"
             app:popEnterAnim="@anim/anim_pop_enter"
             app:popExitAnim="@anim/anim_pop_exit" />
+        <action
+            android:id="@+id/action_main_to_statefulViewFragment"
+            app:destination="@id/statefulViewFragment"
+            app:enterAnim="@anim/anim_enter"
+            app:exitAnim="@anim/anim_exit"
+            app:popEnterAnim="@anim/anim_pop_enter"
+            app:popExitAnim="@anim/anim_pop_exit"/>
     </fragment>
 
     <fragment
@@ -79,4 +86,15 @@
     <fragment
         android:id="@+id/helloWorldFragment"
         android:name="com.airbnb.mvrx.sample.features.helloworld.HelloWorldFragment" />
+    <fragment
+        android:id="@+id/statefulViewFragment"
+        android:name="com.airbnb.mvrx.sample.features.statefulview.StatefulViewFragment" >
+        <action
+            android:id="@+id/action_statefulViewFragment_self"
+            app:destination="@id/statefulViewFragment"
+            app:enterAnim="@anim/anim_enter"
+            app:exitAnim="@anim/anim_exit"
+            app:popEnterAnim="@anim/anim_pop_enter"
+            app:popExitAnim="@anim/anim_pop_exit"/>
+    </fragment>
 </navigation>


### PR DESCRIPTION
**This PR is still undergoing active development**

This PR enables the retrieving and subscribing to ViewModels in a view-lifeycle-aware way. To use MvRx in a custom view, make your custom view implement `StatefulView` and override `onInvalidate()`. Naming is tough here because `MvRxView` is already taken and View already has an `invalidate()` function... But I'm open to alternative names.

Fragment retrieval works by walking up the view hierarchy from the custom view until it reaches the root view of a Fragment that is in any FragmentManager or child FragmentManager of the view's Activity.

Thoughts? Any reasons you can think of that this wouldn't work?

I'll add tests once we agree on this as a path forward.

As a demo, I created a counter where the text views subscribe to the state rather than needing the state passed in from the Fragment. 
![CustomView](https://user-images.githubusercontent.com/1307745/59939493-fa37f380-940c-11e9-80b3-4a01b6c98804.gif)


### Potential TODO
* Remove the ability to change a key and VM memoization
* Create a function on BaseMvRxFragment to fetch a ViewModel and pass it optional args but just return it without subscribing. This can be passed to a View
* Remove StatefulView and the concept of invalidate on VIews
* Create subscribe and selectSubscribe for Views. If a new VM is passed in, it is responsible for managing the old subscription disposables.
* We might want to make ViewViewModelStore clear a ViewModel when the key changes because each one might be holding on to SQL triggers and if the key changes frequently, they will just accumulate.