### PR TITLE
Add Completable execute without the function to handle output

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -156,14 +156,14 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     }
 
     /**
-     * Helper to map an Single to an Async property on the state object.
+     * Helper to map a Single to an Async property on the state object.
      */
     fun <T> Single<T>.execute(
         stateReducer: S.(Async<T>) -> S
     ) = toObservable().execute({ it }, null, stateReducer)
 
     /**
-     * Helper to map an Single to an Async property on the state object.
+     * Helper to map a Single to an Async property on the state object.
      * @param mapper A map converting the observable type to the desired AsyncData type.
      * @param stateReducer A reducer that is applied to the current state and should return the
      *                     new state. Because the state is the receiver and it likely a data
@@ -175,7 +175,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     ) = toObservable().execute(mapper, null, stateReducer)
 
     /**
-     * Helper to map an observable to an Async property on the state object.
+     * Helper to map an Observable to an Async property on the state object.
      */
     fun <T> Observable<T>.execute(
         stateReducer: S.(Async<T>) -> S
@@ -186,7 +186,12 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      */
     fun Completable.execute(
         stateReducer: S.(Async<Unit>) -> S
-    ) = toSingle { Unit }.execute(stateReducer)
+    ) = toObservable<Unit>().execute(stateReducer)
+
+    /**
+     * Helper to subscribe to a Completable and ignore its output.
+     */
+    fun Completable.execute() = toObservable<Unit>().execute { this }
 
     /**
      * Execute an observable and wrap its progression with AsyncData reduced to the global state.


### PR DESCRIPTION
### Problem

Only when I have a `Completable` source, I couple of time had the condition where I had no way to handle `Async<Unit>` that comes with the callback from `Completable.execute`.

### Solution

The solution that I had locally is to have `Completable.subscribe().disposeOnClear()`. This is far from ideal. 

The solution that I'm proposing here is to have `execute` function overloaded for `Completable` with no arguments.

### Considerations

This is definitely going to be handy. But I was wondering what you may all think about it. It allows you to (very easily) skip/ignore any failures. Is that something you would be fine. At the end, it will be up to the user.