### PR TITLE
Some RxJava clean up

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -207,13 +207,12 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         successMetaData: ((T) -> Any)? = null,
         stateReducer: S.(Async<V>) -> S
     ): Disposable {
-        setState { stateReducer(Loading()) }
-
-        return map { value ->
-            val success = Success(mapper(value))
-            success.metadata = successMetaData?.invoke(value)
-            success as Async<V>
+        return map<Async<V>> { value ->
+            Success(mapper(value)).also {
+                it.metadata = successMetaData?.invoke(value)
+            }
         }
+            .startWith(Loading())
             .onErrorReturn { Fail(it) }
             .subscribe { asyncData -> setState { stateReducer(asyncData) } }
             .disposeOnClear()


### PR DESCRIPTION
I've seen this little piece that I can improve in `execute` function. Let me know what you think. 

- Use Kotlin's `also` to set `metadata` as a side-effect
- Use RxJava's `startWith(Loading())`. I believe it is more clear to read.