### PR TITLE
Make minSdk 21 in all samples to fix #199

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     ext.navVersion = '2.0.0'
     ext.roomVersion = '2.0.0'
     ext.buildToolsVersion = '28.0.3'
-    ext.androidXTestVersion = '1.1.0'
     ext.espressoVersion = '3.1.1'
 
     repositories {

--- a/counter/build.gradle
+++ b/counter/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+
 android {
     compileSdkVersion 28
 
@@ -10,12 +11,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
     }
 }
 

--- a/dogs/build.gradle
+++ b/dogs/build.gradle
@@ -12,14 +12,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.airbnb.sample"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
@@ -32,9 +32,8 @@ dependencies {
     implementation project(':mvrx')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    // TODO: clean up the support library dependency resolution.
-    implementation("androidx.appcompat:appcompat:$appCompatVersion") { exclude group: 'android.arch.lifecycle' }
-    implementation("androidx.recyclerview:recyclerview:$recyclerViewVersion") { exclude group: 'android.arch.lifecycle' }
+    implementation "androidx.appcompat:appcompat:$appCompatVersion"
+    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation("com.airbnb.android:epoxy:$epoxyVersion") { exclude group: 'com.android.support' }
@@ -48,9 +47,9 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
     implementation "org.koin:koin-android-architecture:$koinVersion"
+    implementation "org.koin:koin-android:$koinVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
+
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation "androidx.test:runner:$androidXTestVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 }

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.airbnb.mvrx.todoapp"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
@@ -15,18 +15,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildToolsVersion "$buildToolsVersion"
-
-    android {
-        sourceSets {
-            String sharedTestDir = 'src/sharedTest/java'
-            test {
-                java.srcDir sharedTestDir
-            }
-            androidTest {
-                java.srcDir sharedTestDir
-            }
-        }
-    }
 }
 
 androidExtensions {
@@ -45,12 +33,6 @@ dependencies {
     kapt "com.airbnb.android:epoxy-processor:$epoxyVersion"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "io.reactivex.rxjava2:rxjava:2.2.8"
-    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    implementation "com.squareup.moshi:moshi:$moshiVersion"
-    implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
     implementation "org.koin:koin-android-architecture:$koinVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
@@ -59,9 +41,8 @@ dependencies {
     kapt "androidx.room:room-compiler:$roomVersion"
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
     debugImplementation 'com.amitshekhar.android:debug-db:1.0.4'
+
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
     testImplementation project(':testing')
-    androidTestImplementation "androidx.test:runner:$androidXTestVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 }


### PR DESCRIPTION
Make minSdk 21 in all samples 

The other samples were already 21. `mvrx` library dependencies have `minSdkVersion = 16`

Also clean-up unneeded declarations and unneeded dependencies in sample gradle configurations for simplicity. Sorry for putting all this together but I think they're good clean-up. Run all the samples and verified that they work well.

Fixes #199