### PR TITLE
Fix a uniqueId related problem in unit tests

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -3,7 +3,6 @@ package com.airbnb.mvrx
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
-import java.util.UUID
 
 /**
  * Make your base Fragment class extend this to get MvRx functionality.
@@ -14,13 +13,12 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
 
     override val mvrxViewModelStore by lazy { MvRxViewModelStore(viewModelStore) }
 
-    final override val mvrxViewId: String by lazy { mvrxPersistedViewId ?: generateUniqueId() }
-
-    private var mvrxPersistedViewId: String? = null
+    private val mvrxViewIdProperty = MvRxViewId()
+    final override val mvrxViewId: String by mvrxViewIdProperty
 
     override fun onCreate(savedInstanceState: Bundle?) {
         mvrxViewModelStore.restoreViewModels(this, savedInstanceState)
-        mvrxPersistedViewId = savedInstanceState?.getString(PERSISTED_VIEW_ID_KEY)
+        mvrxViewIdProperty.restoreFrom(savedInstanceState)
         super.onCreate(savedInstanceState)
     }
 
@@ -34,7 +32,7 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         mvrxViewModelStore.saveViewModels(outState)
-        outState.putString(PERSISTED_VIEW_ID_KEY, mvrxViewId)
+        mvrxViewIdProperty.saveTo(outState)
     }
 
     override fun onStart() {
@@ -43,8 +41,4 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
         // subscribe to a ViewModel.
         postInvalidate()
     }
-
-    private fun generateUniqueId() = this::class.java.simpleName + "_" + UUID.randomUUID().toString()
 }
-
-private const val PERSISTED_VIEW_ID_KEY = "mvrx:persisted_view_id"

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -14,13 +14,13 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
 
     override val mvrxViewModelStore by lazy { MvRxViewModelStore(viewModelStore) }
 
-    final override val mvrxViewId: String by lazy { mvrxPersistedViewId }
+    final override val mvrxViewId: String by lazy { mvrxPersistedViewId ?: generateUniqueId() }
 
-    private lateinit var mvrxPersistedViewId: String
+    private var mvrxPersistedViewId: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         mvrxViewModelStore.restoreViewModels(this, savedInstanceState)
-        mvrxPersistedViewId = savedInstanceState?.getString(PERSISTED_VIEW_ID_KEY) ?: this::class.java.simpleName + "_" + UUID.randomUUID().toString()
+        mvrxPersistedViewId = savedInstanceState?.getString(PERSISTED_VIEW_ID_KEY)
         super.onCreate(savedInstanceState)
     }
 
@@ -43,6 +43,8 @@ abstract class BaseMvRxFragment : Fragment(), MvRxView {
         // subscribe to a ViewModel.
         postInvalidate()
     }
+
+    private fun generateUniqueId() = this::class.java.simpleName + "_" + UUID.randomUUID().toString()
 }
 
 private const val PERSISTED_VIEW_ID_KEY = "mvrx:persisted_view_id"

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewId.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewId.kt
@@ -1,0 +1,38 @@
+package com.airbnb.mvrx
+
+import android.os.Bundle
+import java.util.*
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class MvRxViewId : ReadOnlyProperty<MvRxView, String> {
+
+    private var value: String? = null
+
+    override fun getValue(thisRef: MvRxView, property: KProperty<*>): String {
+        val currentValue = value
+        return if (currentValue == null) {
+            val id = generateUniqueId(thisRef)
+            value = id
+            id
+        } else {
+            currentValue
+        }
+    }
+
+    private fun generateUniqueId(thisRef: MvRxView) = thisRef::class.java.simpleName + "_" + UUID.randomUUID().toString()
+
+    fun saveTo(bundle: Bundle) {
+        bundle.putString(PERSISTED_VIEW_ID_KEY, value)
+    }
+
+    fun restoreFrom(bundle: Bundle?) {
+        if (value == null) {
+            value = bundle?.getString(PERSISTED_VIEW_ID_KEY)
+        }
+    }
+
+    companion object {
+        private const val PERSISTED_VIEW_ID_KEY = "mvrx:persisted_view_id"
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewId.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewId.kt
@@ -10,14 +10,7 @@ class MvRxViewId : ReadOnlyProperty<MvRxView, String> {
     private var value: String? = null
 
     override fun getValue(thisRef: MvRxView, property: KProperty<*>): String {
-        val currentValue = value
-        return if (currentValue == null) {
-            val id = generateUniqueId(thisRef)
-            value = id
-            id
-        } else {
-            currentValue
-        }
+        return value ?: generateUniqueId(thisRef).also { value = it }
     }
 
     private fun generateUniqueId(thisRef: MvRxView) = thisRef::class.java.simpleName + "_" + UUID.randomUUID().toString()


### PR DESCRIPTION
### Problem

Using `uniqueOnly()` in a class that is unit tested crashes because of lateinit not being initialized. In unit tests, `onCreate` is never called. That means that the lateinit will never be instantiated. 

### Solution

Instead, make `persistedViewId` only contain the persisted id. That means it is nullable now. Initially there is no persisted id and it makes sense. 

Then when `mvrxId` is accessed for the first time, we generate the id. And later if the user changes orientation, it should be persisted. 

Functionality wise, this change should behave 100% the same. But it fixes a problem with unit testing view layer.