### PR TITLE
Fix shrinking with cache warming

### DIFF
--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -34,6 +34,7 @@
 
 # Members of the Kotlin data classes used as the state in MvRx are read via Kotlin reflection which cause trouble
 # with Proguard if they are not kept.
--keepclassmembers class ** implements com.airbnb.mvrx.MvRxState {
+# During reflection cache warming also the types are accessed via reflection. Need to keep them too.
+-keepclassmembers,includedescriptorclasses class ** implements com.airbnb.mvrx.MvRxState {
    *;
 }


### PR DESCRIPTION
During reflection cache warming also the types are accessed via reflection. Need to keep them too.

This should fix https://github.com/airbnb/MvRx/issues/253