### PR TITLE
Proguard cleanup and bugfixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'net.sf.proguard:proguard-gradle:6.1.1'
     }
 }
 

--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -34,7 +34,8 @@
 
 # Members of the Kotlin data classes used as the state in MvRx are read via Kotlin reflection which cause trouble
 # with Proguard if they are not kept.
--keepclassmembers class ** implements com.airbnb.mvrx.MvRxState {
+# During reflection cache warming also the types are accessed via reflection. Need to keep them too.
+-keepclassmembers,includedescriptorclasses class ** implements com.airbnb.mvrx.MvRxState {
    *;
 }
 

--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -37,3 +37,8 @@
 -keepclassmembers class ** implements com.airbnb.mvrx.MvRxState {
    *;
 }
+
+# The MvRxState object and the names classes that implement the MvRxState interfrace need to be
+# kept as they are accessed via reflection.
+-keepnames class com.airbnb.mvrx.MvRxState
+-keepnames class * implements com.airbnb.mvrx.MvRxState

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,6 +21,11 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
         }
+        debug {
+//            minifyEnabled true
+//            shrinkResources true
+//            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
+        }
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,11 +21,6 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
         }
-        debug {
-//            minifyEnabled true
-//            shrinkResources true
-//            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
-        }
     }
 }
 

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -40,9 +40,6 @@
    long consumerIndex;
 }
 
-# Oddly need to keep that even though Evernote state is not used in the app.
-#-keepnames class * { @com.evernote.android.state.State *;}
-
 #
 # Keep rules that are unique to the sample project because it uses epoxy, okhttp3, moshi and retrofit.
 #

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -161,16 +161,9 @@
     public <methods>;
 }
 
--dontwarn com.airbnb.mvrx.sample.features.parentfragment.ChildFragment$$special$$inlined$parentFragmentViewModel$1
+#
+# For Kotlin reflection
+#
 
--keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+-keep interface kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader
 
--keep class kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition
-
--keep class kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition
-
--keep class kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition
-
--keep interface  kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader
-
--keep class kotlin.reflect.jvm.internal.impl.serialization.deserialization.builtins.BuiltInsLoaderImpl

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -41,7 +41,7 @@
 }
 
 # Oddly need to keep that even though Evernote state is not used in the app.
--keepnames class * { @com.evernote.android.state.State *;}
+#-keepnames class * { @com.evernote.android.state.State *;}
 
 #
 # Keep rules that are unique to the sample project because it uses epoxy, okhttp3, moshi and retrofit.
@@ -160,3 +160,17 @@
 -keepclassmembers class kotlin.Metadata {
     public <methods>;
 }
+
+-dontwarn com.airbnb.mvrx.sample.features.parentfragment.ChildFragment$$special$$inlined$parentFragmentViewModel$1
+
+-keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+
+-keep class kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition
+
+-keep class kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition
+
+-keep class kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition
+
+-keep interface  kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader
+
+-keep class kotlin.reflect.jvm.internal.impl.serialization.deserialization.builtins.BuiltInsLoaderImpl

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldEpoxyFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldEpoxyFragment.kt
@@ -11,7 +11,7 @@ class HelloWorldEpoxyFragment : BaseFragment() {
     override fun epoxyController() = simpleController(viewModel) { state ->
         marquee {
             id("marquee")
-            title(state.title)
+            title(state.title.value)
         }
     }
 }

--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldViewModel.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/helloworld/HelloWorldViewModel.kt
@@ -3,6 +3,9 @@ package com.airbnb.mvrx.sample.features.helloworld
 import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.sample.core.MvRxViewModel
 
-data class HelloWorldState(val title: String = "Hello World") : MvRxState
+data class HelloWorldState(val title: HelloWorld = HelloWorld()) : MvRxState
+
+// This is done to have a non primitive type element in the state object
+data class HelloWorld (val value: String = "Hello World")
 
 class HelloWorldViewModel(initialState: HelloWorldState) : MvRxViewModel<HelloWorldState>(initialState)


### PR DESCRIPTION
Fixes https://github.com/airbnb/MvRx/issues/253

- Update Proguard used to latest 6.1.1
- Fix an issue with types of data classes implementing `MvRxState` needing to keep the type for reflection cache pre warming
- Changed sample app so it can repro this type not being kept
- Updated lib shrink rules 
- Removed odd rule that did not make any sense and is now replace by better keep rules for the lib