### PR TITLE
Update MvRx sample module to Koin 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.robolectricVersion = '4.0.2'
     ext.epoxyVersion = '3.2.0'
     ext.moshiVersion = '1.6.0'
-    ext.koinVersion = '0.9.3'
+    ext.koinVersion = '2.0.1'
     ext.retrofitVersion = '2.4.0'
     ext.navVersion = '2.0.0'
     ext.roomVersion = '2.0.0'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -46,10 +46,9 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshiVersion"
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
-    implementation "org.koin:koin-android-architecture:$koinVersion"
-    implementation "org.koin:koin-android:$koinVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
+    implementation "org.koin:koin-android:$koinVersion"
 
     testImplementation 'junit:junit:4.12'
 }

--- a/sample/src/main/java/com/airbnb/mvrx/sample/core/MvRxApplication.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/core/MvRxApplication.kt
@@ -4,29 +4,40 @@ import android.app.Application
 import com.airbnb.mvrx.sample.network.DadJokeService
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import org.koin.android.ext.android.startKoin
-import org.koin.dsl.module.Module
-import org.koin.dsl.module.applicationContext
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 class MvRxApplication : Application() {
 
-    private val dadJokeServiceModule: Module = applicationContext {
-        bean {
-            val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
-            val retrofit = Retrofit.Builder()
-                .baseUrl("https://icanhazdadjoke.com/")
-                .addConverterFactory(MoshiConverterFactory.create(moshi))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-                .build()
-            retrofit.create(DadJokeService::class.java)
-        }
-    }
-
     override fun onCreate() {
         super.onCreate()
-        startKoin(this, listOf(dadJokeServiceModule))
+        startKoin {
+            androidContext(this@MvRxApplication)
+            modules(dadJokeServiceModule)
+        }
+    }
+}
+
+private val dadJokeServiceModule = module {
+    factory {
+        Moshi.Builder()
+                .add(KotlinJsonAdapterFactory())
+                .build()
+    }
+
+    factory {
+        Retrofit.Builder()
+                .baseUrl("https://icanhazdadjoke.com/")
+                .addConverterFactory(MoshiConverterFactory.create(get<Moshi>()))
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .build()
+    }
+
+    single {
+        get<Retrofit>().create(DadJokeService::class.java)
     }
 }

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     kapt "com.airbnb.android:epoxy-processor:$epoxyVersion"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "io.reactivex.rxjava2:rxjava:2.2.8"
-    implementation "org.koin:koin-android-architecture:$koinVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
     implementation "androidx.room:room-runtime:$roomVersion"


### PR DESCRIPTION
Fixes #270 

- Remove old Koin artifacts, and replace them with Koin 2.0 equivalents.
- Update MvRx sample module to use Koin 2.0
- Remove unused Koin dependency from Todo-MvRx Sample.
