### PR TITLE
Delay warming reflection for 500ms

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -16,6 +16,7 @@ import io.reactivex.functions.Consumer
 import io.reactivex.schedulers.Schedulers
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberProperties
@@ -45,7 +46,10 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         get() = stateStore.state
 
     init {
-        Completable.fromCallable { warmReflectionCache(initialState) }.subscribeOn(Schedulers.computation()).subscribe()
+        Completable.fromCallable { warmReflectionCache(initialState) }
+            .delay(500, TimeUnit.MILLISECONDS, Schedulers.computation())
+            .subscribeOn(Schedulers.computation())
+            .subscribe()
 
         if (this.debugMode) {
             mutableStateChecker = MutableStateChecker(initialState)


### PR DESCRIPTION
I did some investigation as per #264 regarding the effect of warming reflection. It takes around 1sec on OnePlus 5 (2 years old). It is considerably high, I would say. That is especially because it is done during construction of the ViewModel.

### Suggested solution: 

Delayed warming for 500 milliseconds.