### PR TITLE
Make searching for the companion object factory more robust

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -87,19 +87,14 @@ object MvRxViewModelProvider {
 }
 
 /**
- * Return the [Class] of the [MvRxViewModelFactory] for a given ViewModel class, if it exists.
+ * Return the [Class] of the companion [MvRxViewModelFactory] for a given ViewModel class, if it exists.
  */
 internal fun <VM : BaseMvRxViewModel<*>> Class<VM>.factoryCompanion(): Class<out MvRxViewModelFactory<VM, *>>? {
-    val companionClass = try {
-        Class.forName("$name\$Companion")
-    } catch (exception: ClassNotFoundException) {
-        return null
-    }
-    return if (MvRxViewModelFactory::class.java.isAssignableFrom(companionClass)) {
+    return declaredClasses.firstOrNull {
+        MvRxViewModelFactory::class.java.isAssignableFrom(it)
+    }?.let {
         @Suppress("UNCHECKED_CAST")
-        companionClass as Class<out MvRxViewModelFactory<VM, *>>
-    } else {
-        null
+        it as Class<out MvRxViewModelFactory<VM, *>>
     }
 }
 

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/FactoryTest.kt
@@ -134,6 +134,16 @@ class FactoryViewModelTest : BaseTest() {
         }
     }
 
+    private class NamedFactoryViewModel(initialState: FactoryState) : TestMvRxViewModel<FactoryState>(initialState) {
+
+        // Ensures we don't accidently consider this to be the factory.
+        class NestedClass
+
+        companion object NamedFactory : MvRxViewModelFactory<NamedFactoryViewModel, FactoryState> {
+            override fun create(viewModelContext: ViewModelContext, state: FactoryState) = NamedFactoryViewModel(state)
+        }
+    }
+
     private class ViewModelContextApplicationFactory(initialState: FactoryState) : TestMvRxViewModel<FactoryState>(initialState) {
         companion object : MvRxViewModelFactory<TestFactoryJvmStaticViewModel, FactoryState> {
             override fun create(viewModelContext: ViewModelContext, state: FactoryState): TestFactoryJvmStaticViewModel? {
@@ -178,6 +188,14 @@ class FactoryViewModelTest : BaseTest() {
             assertEquals(FactoryState("hello constructor"), state)
         }
         assertEquals(5, viewModel.otherProp)
+    }
+
+    @Test
+    fun createWithNamedFactory() {
+        val viewModel = MvRxViewModelProvider.get(NamedFactoryViewModel::class.java, FactoryState::class.java, ActivityViewModelContext(activity, TestArgs("hello")))
+        withState(viewModel) { state ->
+            assertEquals(FactoryState("hello constructor"), state)
+        }
     }
 
     @Test


### PR DESCRIPTION
Ran into an issue with an engineer today where if a MvRxFactory companion object is named, we would fail to find it. This PR changes the search for a companion object to be more robust and search all declared (nested) classes.