### PR TITLE
Adding inter view model subscription support

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -50,17 +50,17 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      * [Lifecycle.State.RESUMED] and when [ViewModel.onCleared] is called the lifecycle will be
      * [Lifecycle.State.DESTROYED].
      *
-     * This is not be publicly accessible as it should only be used to control subscriptions
+     * This is not publicly accessible as it should only be used to control subscriptions
      * between two view models.
      */
     private val lifecycleOwner: LifecycleOwner = LifecycleOwner { lifecycleRegistry }
-    private val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(lifecycleOwner)
+    private val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(lifecycleOwner).apply { currentState = Lifecycle.State.RESUMED }
+
 
     internal val state: S
         get() = stateStore.state
 
     init {
-        lifecycleRegistry.currentState = Lifecycle.State.RESUMED
         Completable.fromCallable { warmReflectionCache(initialState) }.subscribeOn(Schedulers.computation()).subscribe()
 
         if (this.debugMode) {
@@ -658,8 +658,8 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     }
 
     private fun <S : MvRxState> assertSubscribeToDifferentViewModel(viewModel: BaseMvRxViewModel<S>) {
-        if (this == viewModel) {
-            throw IllegalArgumentException("This method is for subscribing to other view models. Please pass a different instance as the argument.")
+        require(this == viewModel) {
+            "This method is for subscribing to other view models. Please pass a different instance as the argument."
         }
     }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -56,7 +56,6 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     private val lifecycleOwner: LifecycleOwner = LifecycleOwner { lifecycleRegistry }
     private val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(lifecycleOwner).apply { currentState = Lifecycle.State.RESUMED }
 
-
     internal val state: S
         get() = stateStore.state
 
@@ -364,6 +363,19 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         subscriber: (A, B) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, RedeliverOnStart, subscriber)
 
+    /**
+     * Subscribe to state changes for two properties in a different ViewModel.
+     */
+    protected fun <A, B> selectSubscribe(
+        viewModel: BaseMvRxViewModel<S>,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        subscriber: (A, B) -> Unit
+    ) {
+        assertSubscribeToDifferentViewModel(viewModel)
+        viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, RedeliverOnStart, subscriber)
+    }
+
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B> selectSubscribe(
         owner: LifecycleOwner,
@@ -393,6 +405,20 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop3: KProperty1<S, C>,
         subscriber: (A, B, C) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, prop3, RedeliverOnStart, subscriber)
+
+    /**
+     * Subscribe to state changes for three properties in a different ViewModel.
+     */
+    protected fun <A, B, C> selectSubscribe(
+        viewModel: BaseMvRxViewModel<S>,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        subscriber: (A, B, C) -> Unit
+    ) {
+        assertSubscribeToDifferentViewModel(viewModel)
+        viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, prop3, RedeliverOnStart, subscriber)
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C> selectSubscribe(
@@ -433,6 +459,21 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         subscriber: (A, B, C, D) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, RedeliverOnStart, subscriber)
 
+    /**
+     * Subscribe to state changes for four properties in a different ViewModel.
+     */
+    protected fun <A, B, C, D> selectSubscribe(
+        viewModel: BaseMvRxViewModel<S>,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        prop4: KProperty1<S, D>,
+        subscriber: (A, B, C, D) -> Unit
+    ) {
+        assertSubscribeToDifferentViewModel(viewModel)
+        viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, prop3, prop4, RedeliverOnStart, subscriber)
+    }
+
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D> selectSubscribe(
         owner: LifecycleOwner,
@@ -471,6 +512,22 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop5: KProperty1<S, E>,
         subscriber: (A, B, C, D, E) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, RedeliverOnStart, subscriber)
+
+    /**
+     * Subscribe to state changes for five properties in a different ViewModel.
+     */
+    protected fun <A, B, C, D, E> selectSubscribe(
+        viewModel: BaseMvRxViewModel<S>,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        prop4: KProperty1<S, D>,
+        prop5: KProperty1<S, E>,
+        subscriber: (A, B, C, D, E) -> Unit
+    ) {
+        assertSubscribeToDifferentViewModel(viewModel)
+        viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, prop3, prop4, prop5, RedeliverOnStart, subscriber)
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D, E> selectSubscribe(
@@ -513,6 +570,23 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop6: KProperty1<S, F>,
         subscriber: (A, B, C, D, E, F) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, prop6, RedeliverOnStart, subscriber)
+
+    /**
+     * Subscribe to state changes for six properties in a different ViewModel.
+     */
+    protected fun <A, B, C, D, E, F> selectSubscribe(
+        viewModel: BaseMvRxViewModel<S>,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        prop4: KProperty1<S, D>,
+        prop5: KProperty1<S, E>,
+        prop6: KProperty1<S, F>,
+        subscriber: (A, B, C, D, E, F) -> Unit
+    ) {
+        assertSubscribeToDifferentViewModel(viewModel)
+        viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, prop3, prop4, prop5, prop6, RedeliverOnStart, subscriber)
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D, E, F> selectSubscribe(
@@ -558,6 +632,24 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop7: KProperty1<S, G>,
         subscriber: (A, B, C, D, E, F, G) -> Unit
     ) = selectSubscribeInternal(null, prop1, prop2, prop3, prop4, prop5, prop6, prop7, RedeliverOnStart, subscriber)
+
+    /**
+     * Subscribe to state changes for seven properties in a different ViewModel.
+     */
+    protected fun <A, B, C, D, E, F, G, H> selectSubscribe(
+        viewModel: BaseMvRxViewModel<S>,
+        prop1: KProperty1<S, A>,
+        prop2: KProperty1<S, B>,
+        prop3: KProperty1<S, C>,
+        prop4: KProperty1<S, D>,
+        prop5: KProperty1<S, E>,
+        prop6: KProperty1<S, F>,
+        prop7: KProperty1<S, H>,
+        subscriber: (A, B, C, D, E, F, H) -> Unit
+    ) {
+        assertSubscribeToDifferentViewModel(viewModel)
+        viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, prop3, prop4, prop5, prop6, prop7, RedeliverOnStart, subscriber)
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun <A, B, C, D, E, F, G> selectSubscribe(

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -366,7 +366,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for two properties in a different ViewModel.
      */
-    protected fun <A, B> selectSubscribe(
+    protected fun <A, B, S : MvRxState> selectSubscribe(
         viewModel: BaseMvRxViewModel<S>,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
@@ -409,7 +409,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for three properties in a different ViewModel.
      */
-    protected fun <A, B, C> selectSubscribe(
+    protected fun <A, B, C, S : MvRxState> selectSubscribe(
         viewModel: BaseMvRxViewModel<S>,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
@@ -462,7 +462,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for four properties in a different ViewModel.
      */
-    protected fun <A, B, C, D> selectSubscribe(
+    protected fun <A, B, C, D, S : MvRxState> selectSubscribe(
         viewModel: BaseMvRxViewModel<S>,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
@@ -516,7 +516,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for five properties in a different ViewModel.
      */
-    protected fun <A, B, C, D, E> selectSubscribe(
+    protected fun <A, B, C, D, E, S : MvRxState> selectSubscribe(
         viewModel: BaseMvRxViewModel<S>,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
@@ -574,7 +574,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for six properties in a different ViewModel.
      */
-    protected fun <A, B, C, D, E, F> selectSubscribe(
+    protected fun <A, B, C, D, E, F, S : MvRxState> selectSubscribe(
         viewModel: BaseMvRxViewModel<S>,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
@@ -636,7 +636,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     /**
      * Subscribe to state changes for seven properties in a different ViewModel.
      */
-    protected fun <A, B, C, D, E, F, G, H> selectSubscribe(
+    protected fun <A, B, C, D, E, F, G, S : MvRxState> selectSubscribe(
         viewModel: BaseMvRxViewModel<S>,
         prop1: KProperty1<S, A>,
         prop2: KProperty1<S, B>,
@@ -644,8 +644,8 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
         prop4: KProperty1<S, D>,
         prop5: KProperty1<S, E>,
         prop6: KProperty1<S, F>,
-        prop7: KProperty1<S, H>,
-        subscriber: (A, B, C, D, E, F, H) -> Unit
+        prop7: KProperty1<S, G>,
+        subscriber: (A, B, C, D, E, F, G) -> Unit
     ) {
         assertSubscribeToDifferentViewModel(viewModel)
         viewModel.selectSubscribeInternal(lifecycleOwner, prop1, prop2, prop3, prop4, prop5, prop6, prop7, RedeliverOnStart, subscriber)
@@ -750,7 +750,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     }
 
     private fun <S : MvRxState> assertSubscribeToDifferentViewModel(viewModel: BaseMvRxViewModel<S>) {
-        require(this == viewModel) {
+        require(this != viewModel) {
             "This method is for subscribing to other view models. Please pass a different instance as the argument."
         }
     }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
@@ -6,12 +6,30 @@ import org.junit.Test
 
 data class OuterViewModelTestState(
     val foo: Int = 0,
+    val prop2: Int = 0,
+    val prop3: Int = 0,
+    val prop4: Int = 0,
+    val prop5: Int = 0,
+    val prop6: Int = 0,
+    val prop7: Int = 0,
     val async: Async<String> = Uninitialized
 ) : MvRxState
 
 class OuterViewModelTestViewModel(initialState: OuterViewModelTestState) : TestMvRxViewModel<OuterViewModelTestState>(initialState) {
 
     fun setFoo(foo: Int) = setState { copy(foo = foo) }
+
+    fun setProp2(value: Int) = setState { copy(prop2 = value) }
+
+    fun setProp3(value: Int) = setState { copy(prop3 = value) }
+
+    fun setProp4(value: Int) = setState { copy(prop4 = value) }
+
+    fun setProp5(value: Int) = setState { copy(prop5 = value) }
+
+    fun setProp6(value: Int) = setState { copy(prop6 = value) }
+
+    fun setProp7(value: Int) = setState { copy(prop7 = value) }
 
     fun setAsync(async: Async<String>) {
         setState { copy(async = async) }
@@ -44,6 +62,65 @@ class InnerViewModelTestViewModel(
 
     fun triggerCleared() {
         onCleared()
+    }
+
+    fun subscribeToTwoProps(viewModel: OuterViewModelTestViewModel, subscriber: () -> Unit) {
+        selectSubscribe(viewModel, OuterViewModelTestState::foo, OuterViewModelTestState::prop2) { _, _ -> subscriber.invoke() }
+    }
+
+    fun subscribeToThreeProps(viewModel: OuterViewModelTestViewModel, subscriber: () -> Unit) {
+        selectSubscribe(
+            viewModel,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3
+        ) { _, _, _ -> subscriber.invoke() }
+    }
+
+    fun subscribeToFourProps(viewModel: OuterViewModelTestViewModel, subscriber: () -> Unit) {
+        selectSubscribe(
+            viewModel,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4
+        ) { _, _, _, _ -> subscriber.invoke() }
+    }
+
+    fun subscribeToFiveProps(viewModel: OuterViewModelTestViewModel, subscriber: () -> Unit) {
+        selectSubscribe(
+            viewModel,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4,
+            OuterViewModelTestState::prop5
+        ) { _, _, _, _, _ -> subscriber.invoke() }
+    }
+
+    fun subscribeToSixProps(viewModel: OuterViewModelTestViewModel, subscriber: () -> Unit) {
+        selectSubscribe(
+            viewModel,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4,
+            OuterViewModelTestState::prop5,
+            OuterViewModelTestState::prop6
+        ) { _, _, _, _, _, _ -> subscriber.invoke() }
+    }
+
+    fun subscribeToSevenProps(viewModel: OuterViewModelTestViewModel, subscriber: () -> Unit) {
+        selectSubscribe(
+            viewModel,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4,
+            OuterViewModelTestState::prop5,
+            OuterViewModelTestState::prop6,
+            OuterViewModelTestState::prop7
+        ) { _, _, _, _, _, _, _ -> subscriber.invoke() }
     }
 }
 
@@ -117,5 +194,101 @@ class InnerViewModelSubscriberTest : BaseTest() {
         assertEquals(1, innerViewModel.subscribeCalled)
         assertEquals(0, innerViewModel.onSuccessCalled)
         assertEquals(0, innerViewModel.onFailCalled)
+    }
+
+    @Test
+    fun testSelectSubscribe2() {
+        var callCount = 0
+        innerViewModel.subscribeToTwoProps(outerViewModel) { callCount++ }
+        assertEquals(1, callCount)
+        outerViewModel.setFoo(1)
+        assertEquals(2, callCount)
+        outerViewModel.setProp2(2)
+        assertEquals(3, callCount)
+    }
+
+    @Test
+    fun testSelectSubscribe3() {
+        var callCount = 0
+        innerViewModel.subscribeToThreeProps(outerViewModel) { callCount++ }
+        assertEquals(1, callCount)
+        outerViewModel.setFoo(1)
+        assertEquals(2, callCount)
+        outerViewModel.setProp2(2)
+        assertEquals(3, callCount)
+        outerViewModel.setProp3(3)
+        assertEquals(4, callCount)
+    }
+
+    @Test
+    fun testSelectSubscribe4() {
+        var callCount = 0
+        innerViewModel.subscribeToFourProps(outerViewModel) { callCount++ }
+        assertEquals(1, callCount)
+        outerViewModel.setFoo(1)
+        assertEquals(2, callCount)
+        outerViewModel.setProp2(2)
+        assertEquals(3, callCount)
+        outerViewModel.setProp3(3)
+        assertEquals(4, callCount)
+        outerViewModel.setProp4(4)
+        assertEquals(5, callCount)
+    }
+
+    @Test
+    fun testSelectSubscribe5() {
+        var callCount = 0
+        innerViewModel.subscribeToFiveProps(outerViewModel) { callCount++ }
+        assertEquals(1, callCount)
+        outerViewModel.setFoo(1)
+        assertEquals(2, callCount)
+        outerViewModel.setProp2(2)
+        assertEquals(3, callCount)
+        outerViewModel.setProp3(3)
+        assertEquals(4, callCount)
+        outerViewModel.setProp4(4)
+        assertEquals(5, callCount)
+        outerViewModel.setProp5(5)
+        assertEquals(6, callCount)
+    }
+
+    @Test
+    fun testSelectSubscribe6() {
+        var callCount = 0
+        innerViewModel.subscribeToSixProps(outerViewModel) { callCount++ }
+        assertEquals(1, callCount)
+        outerViewModel.setFoo(1)
+        assertEquals(2, callCount)
+        outerViewModel.setProp2(2)
+        assertEquals(3, callCount)
+        outerViewModel.setProp3(3)
+        assertEquals(4, callCount)
+        outerViewModel.setProp4(4)
+        assertEquals(5, callCount)
+        outerViewModel.setProp5(5)
+        assertEquals(6, callCount)
+        outerViewModel.setProp6(6)
+        assertEquals(7, callCount)
+    }
+
+    @Test
+    fun testSelectSubscribe7() {
+        var callCount = 0
+        innerViewModel.subscribeToSevenProps(outerViewModel) { callCount++ }
+        assertEquals(1, callCount)
+        outerViewModel.setFoo(1)
+        assertEquals(2, callCount)
+        outerViewModel.setProp2(2)
+        assertEquals(3, callCount)
+        outerViewModel.setProp3(3)
+        assertEquals(4, callCount)
+        outerViewModel.setProp4(4)
+        assertEquals(5, callCount)
+        outerViewModel.setProp5(5)
+        assertEquals(6, callCount)
+        outerViewModel.setProp6(6)
+        assertEquals(7, callCount)
+        outerViewModel.setProp7(7)
+        assertEquals(8, callCount)
     }
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
@@ -1,0 +1,121 @@
+package com.airbnb.mvrx
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+data class OuterViewModelTestState(
+    val foo: Int = 0,
+    val async: Async<String> = Uninitialized
+) : MvRxState
+
+class OuterViewModelTestViewModel(initialState: OuterViewModelTestState) : TestMvRxViewModel<OuterViewModelTestState>(initialState) {
+
+    fun setFoo(foo: Int) = setState { copy(foo = foo) }
+
+    fun setAsync(async: Async<String>) {
+        setState { copy(async = async) }
+    }
+
+    fun triggerCleared() {
+        onCleared()
+    }
+}
+
+data class InnerViewModelTestState(
+    val foo: Int = 0
+) : MvRxState
+
+class InnerViewModelTestViewModel(
+    initialState: InnerViewModelTestState,
+    outerViewModelTestViewModel: OuterViewModelTestViewModel
+) : TestMvRxViewModel<InnerViewModelTestState>(initialState) {
+
+    var subscribeCalled = 0
+    var selectSubscribeCalled = 0
+    var onSuccessCalled = 0
+    var onFailCalled = 0
+
+    init {
+        subscribe(outerViewModelTestViewModel) { subscribeCalled++ }
+        selectSubscribe(outerViewModelTestViewModel, OuterViewModelTestState::foo) { selectSubscribeCalled++ }
+        asyncSubscribe(outerViewModelTestViewModel, OuterViewModelTestState::async, { onFailCalled++ }) { onSuccessCalled++ }
+    }
+
+    fun triggerCleared() {
+        onCleared()
+    }
+}
+
+class InnerViewModelSubscriberTest : BaseTest() {
+
+    private lateinit var innerViewModel: InnerViewModelTestViewModel
+    private lateinit var outerViewModel: OuterViewModelTestViewModel
+
+    @Before
+    fun setup() {
+        outerViewModel = OuterViewModelTestViewModel(OuterViewModelTestState())
+        innerViewModel = InnerViewModelTestViewModel(InnerViewModelTestState(), outerViewModel)
+    }
+
+    @Test
+    fun testSubscribe() {
+        assertEquals(1, innerViewModel.subscribeCalled)
+    }
+
+    @Test
+    fun testSelectSubscribe() {
+        assertEquals(1, innerViewModel.selectSubscribeCalled)
+    }
+
+    @Test
+    fun testNotChangingFoo() {
+        outerViewModel.setFoo(0)
+        assertEquals(1, innerViewModel.subscribeCalled)
+        assertEquals(0, innerViewModel.onSuccessCalled)
+        assertEquals(0, innerViewModel.onFailCalled)
+    }
+
+    @Test
+    fun testChangingFoo() {
+        outerViewModel.setFoo(1)
+        assertEquals(2, innerViewModel.subscribeCalled)
+        assertEquals(0, innerViewModel.onSuccessCalled)
+        assertEquals(0, innerViewModel.onFailCalled)
+    }
+
+    @Test
+    fun testSuccess() {
+        outerViewModel.setAsync(Success("Hello World"))
+        assertEquals(2, innerViewModel.subscribeCalled)
+        assertEquals(1, innerViewModel.onSuccessCalled)
+    }
+
+    @Test
+    fun testFail() {
+        outerViewModel.setAsync(Fail(IllegalStateException("foo")))
+        assertEquals(2, innerViewModel.subscribeCalled)
+        assertEquals(0, innerViewModel.onSuccessCalled)
+        assertEquals(1, innerViewModel.onFailCalled)
+    }
+
+    @Test
+    fun testChangesAfterInnerCleared() {
+        innerViewModel.triggerCleared()
+        outerViewModel.setAsync(Success("Hello World"))
+        outerViewModel.setFoo(1)
+        assertEquals(1, innerViewModel.subscribeCalled)
+        assertEquals(0, innerViewModel.onSuccessCalled)
+        assertEquals(0, innerViewModel.onFailCalled)
+    }
+
+    @Test
+    fun testChangesAfterOuterCleared() {
+        outerViewModel.triggerCleared()
+        outerViewModel.setFoo(1)
+        outerViewModel.setAsync(Success("Hello World"))
+        assertEquals(1, innerViewModel.subscribeCalled)
+        assertEquals(0, innerViewModel.onSuccessCalled)
+        assertEquals(0, innerViewModel.onFailCalled)
+    }
+}

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
@@ -38,6 +38,77 @@ class OuterViewModelTestViewModel(initialState: OuterViewModelTestState) : TestM
     fun triggerCleared() {
         onCleared()
     }
+
+    fun subscribeSameViewModel() {
+        subscribe(this) { }
+    }
+
+    fun asyncSubscribeSameViewModel() {
+        asyncSubscribe(this, OuterViewModelTestState::async) { }
+    }
+
+    fun selectSubscribeSameViewModel() {
+        selectSubscribe(this, OuterViewModelTestState::foo) { }
+    }
+
+    fun subscribeToTwoPropsSameViewModel() {
+        selectSubscribe(this, OuterViewModelTestState::foo, OuterViewModelTestState::prop2) { _, _ -> }
+    }
+
+    fun subscribeToThreePropsSameViewModel() {
+        selectSubscribe(
+            this,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3
+        ) { _, _, _ -> }
+    }
+
+    fun subscribeToFourPropsSameViewModel() {
+        selectSubscribe(
+            this,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4
+        ) { _, _, _, _ -> }
+    }
+
+    fun subscribeToFivePropsSameViewModel() {
+        selectSubscribe(
+            this,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4,
+            OuterViewModelTestState::prop5
+        ) { _, _, _, _, _ -> }
+    }
+
+    fun subscribeToSixPropsSameViewModel() {
+        selectSubscribe(
+            this,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4,
+            OuterViewModelTestState::prop5,
+            OuterViewModelTestState::prop6
+        ) { _, _, _, _, _, _ -> }
+    }
+
+    fun subscribeToSevenPropsSameViewModel() {
+        selectSubscribe(
+            this,
+            OuterViewModelTestState::foo,
+            OuterViewModelTestState::prop2,
+            OuterViewModelTestState::prop3,
+            OuterViewModelTestState::prop4,
+            OuterViewModelTestState::prop5,
+            OuterViewModelTestState::prop6,
+            OuterViewModelTestState::prop7
+        ) { _, _, _, _, _, _, _ -> }
+    }
 }
 
 data class InnerViewModelTestState(
@@ -290,5 +361,50 @@ class InnerViewModelSubscriberTest : BaseTest() {
         assertEquals(7, callCount)
         outerViewModel.setProp7(7)
         assertEquals(8, callCount)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSubscribe() {
+        outerViewModel.subscribeSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelAsyncSubscribe() {
+        outerViewModel.asyncSubscribeSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe() {
+        outerViewModel.selectSubscribeSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe2() {
+        outerViewModel.subscribeToTwoPropsSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe3() {
+        outerViewModel.subscribeToThreePropsSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe4() {
+        outerViewModel.subscribeToFourPropsSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe5() {
+        outerViewModel.subscribeToFivePropsSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe6() {
+        outerViewModel.subscribeToSixPropsSameViewModel()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSameViewModelSelectSubscribe7() {
+        outerViewModel.subscribeToSevenPropsSameViewModel()
     }
 }


### PR DESCRIPTION
When a view model contains a reference to another view model it'd be nice to allow it to subscribe to property changes. A use case is when a Fragment's view model contains a reference to the Activity's view model. Without this subscription support, the Fragment would have to contain the communication logic between the two view models.