### PR TITLE
Fix crash on Dad Jokes example

### DIFF
--- a/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexFragment.kt
+++ b/sample/src/main/java/com/airbnb/mvrx/sample/features/dadjoke/DadJokeIndexFragment.kt
@@ -24,6 +24,7 @@ class DadJokeIndexFragment : BaseFragment() {
     private val viewModel: DadJokeIndexViewModel by fragmentViewModel()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         /**
          * Use viewModel.subscribe to listen for changes. The parameter is a shouldUpdate
          * function that is given the old state and new state and returns whether or not to


### PR DESCRIPTION
I was doing some testing and noticed a crash on this example since we are now assigning the recyclerView variable in `onViewCreated` of `BaseFragment` instead of `onCreateView` (from https://github.com/airbnb/MvRx/pull/285)

@gpeal