### PR TITLE
Fix reproducible crash on minified applications using MvRx.

### DIFF
--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -43,3 +43,6 @@
 # kept as they are accessed via reflection.
 -keepnames class com.airbnb.mvrx.MvRxState
 -keepnames class * implements com.airbnb.mvrx.MvRxState
+
+# Retains the metadata necessary for Kotlin Reflection to identify the primaryConstructor of KClass
+-keep class kotlin.Metadata { *; }


### PR DESCRIPTION
Crash is triggered in `PersistState.persistState` when it looks for the `primaryConstructor` of the `MvRxState`.  The metadata that Kotlin reflection uses to indicate the `primaryConstructor` is stripped by Proguard without this rule.

Fixes Issue: https://github.com/airbnb/MvRx/issues/299