### PR TITLE
Fix Proguard issues with TodoMvRx sample app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,13 @@ buildscript {
         classpath 'net.sf.proguard:proguard-gradle:6.1.1'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.8.0'
     }
+
+    configurations.all {
+        resolutionStrategy {
+            // Use Proguard 6.2.0
+            force 'net.sf.proguard:proguard-gradle:6.2.0'
+        }
+    }
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ POM_DEVELOPER_NAME=Airbnb
 POM_INCEPTION_YEAR=2018
 android.useAndroidX = true
 android.enableJetifier = true
+# Set to false if you want to use Proguard
+android.enableR8=true

--- a/sample/proguard-project.pro
+++ b/sample/proguard-project.pro
@@ -124,27 +124,26 @@
     <init>(...);
     <fields>;
 }
-# Proguard bug: https://sourceforge.net/p/proguard/bugs/731/
-#-if @com.squareup.moshi.JsonClass class **$*$*
-#-keep class <1>_<2>_<3>JsonAdapter {
-#    <init>(...);
-#    <fields>;
-#}
-#-if @com.squareup.moshi.JsonClass class **$*$*$*
-#-keep class <1>_<2>_<3>_<4>JsonAdapter {
-#    <init>(...);
-#    <fields>;
-#}
-#-if @com.squareup.moshi.JsonClass class **$*$*$*$*
-#-keep class <1>_<2>_<3>_<4>_<5>JsonAdapter {
-#    <init>(...);
-#    <fields>;
-#}
-#-if @com.squareup.moshi.JsonClass class **$*$*$*$*$*
-#-keep class <1>_<2>_<3>_<4>_<5>_<6>JsonAdapter {
-#    <init>(...);
-#    <fields>;
-#}
+-if @com.squareup.moshi.JsonClass class **$*$*
+-keep class <1>_<2>_<3>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*$*
+-keep class <1>_<2>_<3>_<4>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*$*$*
+-keep class <1>_<2>_<3>_<4>_<5>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*$*$*$*
+-keep class <1>_<2>_<3>_<4>_<5>_<6>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
 
 
 # 

--- a/todomvrx/proguard-rules.pro
+++ b/todomvrx/proguard-rules.pro
@@ -1,21 +1,49 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# This file contains project specific proguard rules
+
+-android
+
+# Print out the full proguard config used for every build
+-printconfiguration build/outputs/fullProguardConfig.pro
+
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Keep rules that are used because MvRx uses Kotlin, Kotlin reflection and RxJava. These are not defined in the
+# lib as they are not specific to the lib itself but need to be most likely present in any project that uses
+# Kotlin, Kotlin reflection and RxJava.
+#
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# These classes are used via kotlin reflection and the keep might not be required anymore once Proguard supports
+# Kotlin reflection directly.
+-keep interface kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader
+-keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+-keep class kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition
+-keep class kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition
+-keep class kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# If Companion objects are instantiated via Kotlin reflection and they extend/implement a class that Proguard
+# would have removed or inlined we run into trouble as the inheritance is still in the Metadata annotation
+# read by Kotlin reflection.
+# FIXME Remove if Kotlin reflection is supported by Pro/Dexguard
+-if class **$Companion extends **
+-keep class <2>
+-if class **$Companion implements **
+-keep class <2>
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# https://medium.com/@AthorNZ/kotlin-metadata-jackson-and-proguard-f64f51e5ed32
+-keep class kotlin.Metadata { *; }
+
+# https://stackoverflow.com/questions/33547643/how-to-use-kotlin-with-proguard
+-dontwarn kotlin.**
+
+# RxJava
+-keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
+   long producerIndex;
+   long consumerIndex;
+}
+
+#
+# Keep rules that are unique to the sample project because it uses epoxy
+#
+
+# The code is safeguarded against API28 use so we can just ignore the warning bout Handler.createAsync(looper) not existing.
+# Can be removed when compiled against API >=28
+-dontwarn com.airbnb.epoxy.EpoxyAsyncUtil


### PR DESCRIPTION
- Added a proguard config to `todomvrx` sample app.
- Update proguard to latest (even though project is using R8 by default)
- Add option to `gradle.properties` to easily enable Proguard
- Removed workaround for old Proguard bug in `sample` app Proguard config.

This will fix #299 