### PR TITLE
Prepare for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change log
+
+## Version 1.2.0
+- Make searching for the companion object factory more robust #283
+- Fix infinite thread leaks while flushing queues in state store #302
+- Adding inter view model subscription support #287
+
 ## Version 1.1.0
 - New `parentFragmentViewModel()` and `targetFragmentViewModel()` ViewModel delegate scopes [#247](https://github.com/airbnb/MvRx/pull/247)
 - Disallow functions in state [#250](https://github.com/airbnb/MvRx/pull/250)

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,4 @@ allprojects {
         jcenter()
         maven { url "https://jitpack.io" }
     }
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-        options.addStringOption('encoding', 'UTF-8')
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.0-SNAPSHOT
+VERSION_NAME=1.3.0-SNAPSHOT
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=MvRx is an Android application framework that makes product development fast and fun.
@@ -14,5 +14,7 @@ POM_DEVELOPER_NAME=Airbnb
 POM_INCEPTION_YEAR=2018
 android.useAndroidX = true
 android.enableJetifier = true
+# With the default memory size Gradle gets out of memory issues when building, so we have to increase it
+org.gradle.jvmargs=-Xms128m -Xmx2048m -XX:+CMSClassUnloadingEnabled
 # Set to false if you want to use Proguard
 android.enableR8=true

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -63,32 +63,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
-// Ensure custom source sets are included:
-// https://www.virag.si/2015/01/publishing-gradle-android-library-to-jcenter/
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
-
-tasks.withType(Javadoc).all {
-    enabled = false
-}
-
 task coverage(type: JacocoReport, dependsOn: "testDebugUnitTest") {
     group = "Reporting"
     description = "Generate Jacoco coverage reports for Debug build"

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -42,29 +42,3 @@ dependencies {
     implementation project(':mvrx')
     implementation 'junit:junit:4.12'
 }
-
-// Ensure custom source sets are included:
-// https://www.virag.si/2015/01/publishing-gradle-android-library-to-jcenter/
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
-
-tasks.withType(Javadoc).all {
-    enabled = false
-}


### PR DESCRIPTION
I've released 1.2.0 to maven, and am updating the release notes and snapshot version.

I removed the manual javadoc sources configuration we had, as it is now covered by the gradle push plugin we are using.