### PR TITLE
Remove extra proguard dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'net.sf.proguard:proguard-gradle:6.1.1'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.8.0'
     }
 


### PR DESCRIPTION
Remove old Proguard dependency 

Ran `./gradlew clean build` with both `r8` enabled and disabled to test this.