### PR TITLE
fix: Add support for API 29 in travis config file to fix failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ android:
     - platform-tools
     - build-tools-28.0.2
     - build-tools-28.0.3
+    - build-tools-29.0.2
     - android-28
+    - android-29
     - extra-google-google_play_services
     - extra-android-m2repository
     - extra-android-support

--- a/hellodagger/build.gradle
+++ b/hellodagger/build.gradle
@@ -4,12 +4,12 @@ apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
     buildToolsVersion "$buildToolsVersion"
     defaultConfig {
         applicationId "com.airbnb.mvrx.helloDagger"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/hellodagger/build.gradle
+++ b/hellodagger/build.gradle
@@ -5,7 +5,7 @@ apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "$buildToolsVersion"
+    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.airbnb.mvrx.helloDagger"
         minSdkVersion 21

--- a/hellodagger/build.gradle
+++ b/hellodagger/build.gradle
@@ -4,12 +4,12 @@ apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion "$buildToolsVersion"
     defaultConfig {
         applicationId "com.airbnb.mvrx.helloDagger"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This is a simple fix for the failing build for the `helloDagger` module. This module uses targetSDK v29 and build-tools-29.0.2. They are currently not supported by the travis config file. This PR adds support for them.

~Drops the `targetSDK` and `compileSDK` to version 28 from 29.~ 

~* [Failing Build](https://travis-ci.com/airbnb/MvRx/builds/136049446)~
~* [Successful Build after this change](https://travis-ci.com/haroldadmin/MvRx/builds/136059917)~