### PR TITLE
Work with Kotlin reflection support in shrinker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ The MvRx lib comes with a working configuration in general. However, app specifi
 The configuration provided for the lib assumes that your shrinker can correctly handle Kotlin `@Metadata` annotations (e.g. Dexguard 8.6++) if it cannot (e.g. Proguard and current versions of R8) you need to add these rules to the proguard configuration of your app:
 
 ```
+# BaseMvRxViewModels loads the Companion class via reflection and thus we need to make sure we keep
+# the name of the Companion object.
+-keepclassmembers class ** extends com.airbnb.mvrx.BaseMvRxViewModel {
+    ** Companion;
+}
+
 # Members of the Kotlin data classes used as the state in MvRx are read via Kotlin reflection which cause trouble
 # with Proguard if they are not kept.
 # During reflection cache warming also the types are accessed via reflection. Need to keep them too.
@@ -65,5 +71,6 @@ The configuration provided for the lib assumes that your shrinker can correctly 
 # MvRxViewModelFactory is referenced via reflection using the Companion class name.
 -keepnames class * implements com.airbnb.mvrx.MvRxViewModelFactory
 ```
+
 
 ## For full documentation, check out the [wiki](https://github.com/airbnb/MvRx/wiki)

--- a/README.md
+++ b/README.md
@@ -43,4 +43,27 @@ dependencies {
 ```
 The latest version of mvrx is [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.airbnb.android/mvrx/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.airbnb.android/mvrx)
 
+## Proguard/Dexguard/R8
+
+The MvRx lib comes with a working configuration in general. However, app specific settings are often required. Have a look at the demo apps for one of those.
+
+The configuration provided for the lib assumes that your shrinker can correctly handle Kotlin `@Metadata` annotations (e.g. Dexguard 8.6++) if it cannot (e.g. Proguard and current versions of R8) you need to add these rules to the proguard configuration of your app:
+
+```
+# Members of the Kotlin data classes used as the state in MvRx are read via Kotlin reflection which cause trouble
+# with Proguard if they are not kept.
+# During reflection cache warming also the types are accessed via reflection. Need to keep them too.
+-keepclassmembers,includedescriptorclasses,allowobfuscation class ** implements com.airbnb.mvrx.MvRxState {
+   *;
+}
+
+# The MvRxState object and the names classes that implement the MvRxState interfrace need to be
+# kept as they are accessed via reflection.
+-keepnames class com.airbnb.mvrx.MvRxState
+-keepnames class * implements com.airbnb.mvrx.MvRxState
+
+# MvRxViewModelFactory is referenced via reflection using the Companion class name.
+-keepnames class * implements com.airbnb.mvrx.MvRxViewModelFactory
+```
+
 ## For full documentation, check out the [wiki](https://github.com/airbnb/MvRx/wiki)

--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -4,11 +4,11 @@
 #
 # -----------------------
 
-# BaseMvRxViewModels loads the Companion class via reflection and thus we need to make sure we keep
-# the name of the Companion object.
--keepclassmembers class ** extends com.airbnb.mvrx.BaseMvRxViewModel {
-    ** Companion;
-}
+## BaseMvRxViewModels loads the Companion class via reflection and thus we need to make sure we keep
+## the name of the Companion object.
+#-keepclassmembers class ** extends com.airbnb.mvrx.BaseMvRxViewModel {
+#    ** Companion;
+#}
 
 # Classes extending BaseMvRxViewModel are recreated using reflection, which assumes that a one argument
 # constructor accepting a data class holding the state exists. Need to make sure to keep the constructor
@@ -28,18 +28,9 @@
      public *** initialState(...);
 }
 
-# MvRxViewModelFactory is referenced via reflection using the Companion class name.
--keepnames class * implements com.airbnb.mvrx.MvRxViewModelFactory
-
-
 # Members of the Kotlin data classes used as the state in MvRx are read via Kotlin reflection which cause trouble
 # with Proguard if they are not kept.
 # During reflection cache warming also the types are accessed via reflection. Need to keep them too.
--keepclassmembers,includedescriptorclasses class ** implements com.airbnb.mvrx.MvRxState {
+-keepclassmembers,includedescriptorclasses,allowobfuscation class ** implements com.airbnb.mvrx.MvRxState {
    *;
 }
-
-# The MvRxState object and the names classes that implement the MvRxState interfrace need to be
-# kept as they are accessed via reflection.
--keepnames class com.airbnb.mvrx.MvRxState
--keepnames class * implements com.airbnb.mvrx.MvRxState

--- a/mvrx/proguard-rules.pro
+++ b/mvrx/proguard-rules.pro
@@ -4,12 +4,6 @@
 #
 # -----------------------
 
-## BaseMvRxViewModels loads the Companion class via reflection and thus we need to make sure we keep
-## the name of the Companion object.
-#-keepclassmembers class ** extends com.airbnb.mvrx.BaseMvRxViewModel {
-#    ** Companion;
-#}
-
 # Classes extending BaseMvRxViewModel are recreated using reflection, which assumes that a one argument
 # constructor accepting a data class holding the state exists. Need to make sure to keep the constructor
 # around. Additionally, a static create / inital state method will be generated in the case a


### PR DESCRIPTION
Modify rules to remove the ones from default that are not required if Kotlin reflection is supported by the code shrinker.
This way we can work with Dexguard 8.6+ and have some additional code removed.

I also added this to the Wiki here: https://github.com/airbnb/MvRx/wiki#kotlin-reflection-with-proguarddexguardr8. I'm open to not have the change in the README, but as that this is a change that almost everybody using the lib will have to do when updating I though I put up there too.