### PR TITLE
Prepare for 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 1.4.0
+- Remove Kotlin-Reflect entirely (#334)
+- Remove extra proguard dependency (#310)
+
 ## Version 1.3.0
 - Revamp state saving to use Android Jetpack `SavedStateRegistry` (#254)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.0-SNAPSHOT
+VERSION_NAME=1.5.0-SNAPSHOT
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=MvRx is an Android application framework that makes product development fast and fun.


### PR DESCRIPTION
1.4.0 has been pushed to maven

- Remove Kotlin-Reflect entirely (#334)
- Remove extra proguard dependency (#310)