### PR TITLE
Upgrade compile compatibility to Java 8

### DIFF
--- a/counter/build.gradle
+++ b/counter/build.gradle
@@ -33,6 +33,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {

--- a/dogs/build.gradle
+++ b/dogs/build.gradle
@@ -17,6 +17,15 @@ android {
     dataBinding {
         enabled = true
     }
+
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -20,14 +20,17 @@ android {
         textReport true
         textOutput 'stdout'
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'
     }
+
     testOptions {
         unitTests {
             includeAndroidResources = true

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 androidExtensions {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -27,6 +27,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -13,16 +13,20 @@ android {
         targetSdkVersion 28
         consumerProguardFiles 'proguard-rules.pro'
     }
+
     buildToolsVersion "$buildToolsVersion"
+
     lintOptions {
         abortOnError true
         textReport true
         textOutput 'stdout'
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -15,6 +15,15 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildToolsVersion "$buildToolsVersion"
+
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 androidExtensions {


### PR DESCRIPTION
Details
---------
  - Reformat `mvrx/build.gradle` file
  - Upgrade `counter`, `dogs`, `sample`, and `todomvrx` Java compatibility to v1.8
  - Upgrade `counter`, `dogs`, `sample`, `testing`, and `todomvrx` Kotlin compatibility to v1.8

Fixes
-------
  - [Upgrade compile compatibility to Java 8](https://github.com/airbnb/MvRx/issues/359)