### PR TITLE
build(all): centralized dependencies file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 buildscript {
+    apply from: rootProject.file("dependencies.gradle")
+
     ext.kotlinVersion = '1.3.50'
     ext.appCompatVersion = '1.1.0'
     ext.recyclerViewVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,27 @@
 buildscript {
     apply from: rootProject.file("dependencies.gradle")
 
-    ext.kotlinVersion = '1.3.50'
-    ext.appCompatVersion = '1.1.0'
-    ext.recyclerViewVersion = '1.0.0'
-    ext.constraintLayoutVersion = '1.1.3'
-    ext.lifecycleVersion = '2.1.0'
-    ext.androidXCoreKtxVersion = '1.1.0'
-    ext.robolectricVersion = '4.3'
-    ext.epoxyVersion = '3.2.0'
-    ext.moshiVersion = '1.6.0'
-    ext.koinVersion = '2.0.1'
-    ext.retrofitVersion = '2.4.0'
-    ext.navVersion = '2.1.0'
-    ext.roomVersion = '2.1.0'
-    ext.buildToolsVersion = '28.0.3'
-    ext.espressoVersion = '3.1.1'
-
     repositories {
         google()
         jcenter()
         maven { url "https://oss.sonatype.org/service/local/repositories/snapshots/content/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "com.android.tools.build:gradle:3.5.0"
+        classpath "org.jetbrains.kotlin:kotlin-android-extensions:${versions.kotlin}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
 
         // Upload with:
         // ./gradlew clean assemble androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
         // Need to use snapshot version and explicitly include javadoc/sources tasks until
         // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
+        classpath "com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT"
     }
 
     configurations.all {
         resolutionStrategy {
             // Use Proguard 6.2.0
-            force 'net.sf.proguard:proguard-gradle:6.2.0'
+            force "net.sf.proguard:proguard-gradle:6.2.0"
         }
     }
 }

--- a/counter/build.gradle
+++ b/counter/build.gradle
@@ -7,11 +7,11 @@ android {
     buildToolsVersion versions.buildTools
 
     defaultConfig {
-        applicationId "com.airbnb.mvrx.counter"
+        applicationId 'com.airbnb.mvrx.counter'
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
 
     signingConfigs {
@@ -36,12 +36,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/counter/build.gradle
+++ b/counter/build.gradle
@@ -1,24 +1,25 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         applicationId "com.airbnb.mvrx.counter"
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "1.0"
     }
 
     signingConfigs {
         release {
-            storeFile file('counter.keystore')
-            storePassword 'counter'
-            keyAlias 'counter-release'
-            keyPassword 'counter'
+            storeFile file("counter.keystore")
+            storePassword "counter"
+            keyAlias "counter-release"
+            keyPassword "counter"
         }
     }
 
@@ -30,7 +31,7 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-project.pro"
         }
     }
 
@@ -45,13 +46,13 @@ android {
 }
 
 dependencies {
-    implementation project(':mvrx')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.core:core-ktx:$androidXCoreKtxVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
+    implementation libraries.appcompat
+    implementation libraries.constraintlayout
+    implementation libraries.coreKtx
+    implementation libraries.lifecycleExtensions
+    implementation libraries.kotlin
+    implementation project(":mvrx")
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation project(':testing')
+    testImplementation testLibraries.junit
+    testImplementation project(":testing")
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,105 @@
+ext {
+    versions = [
+            // Build tools and SDK
+            buildTools      : "29.0.3",
+            compileSdk      : 29,
+            jetpack         : "1.1.0",
+            kotlin          : "1.3.50",
+            minSdk          : 16,
+            targetSdk       : 29,
+
+            // Android libraries
+            arch            : "2.1.0",
+            cardview        : "1.0.0",
+            constraintlayout: "1.1.3",
+            core            : "1.1.0",
+            fragment        : "1.2.0-beta02",
+            lifecycle       : "2.1.0",
+            navigation      : "2.1.0",
+            recyclerview    : "1.0.0",
+            room            : "2.1.0",
+
+            // Libraries
+            dagger          : "2.24",
+            daggerAssisted  : "0.5.0",
+            debugDb         : "1.0.4",
+            epoxy           : "3.2.0",
+            koin            : "2.0.1",
+            lottie          : "3.0.0",
+            moshi           : "1.6.0",
+            mvrx            : "1.3.0",
+            picasso         : "2.5.2",
+            retrofit        : "2.4.0",
+            rxAndroid       : "2.1.1",
+            rxJava          : "2.2.8",
+
+            // Instrumented testing libraries
+            espresso        : "3.2.0",
+
+            // Testing libraries
+            junit           : "4.12",
+            junitExt        : "1.1.1",
+            mockito         : "2.25.1",
+            mockitoKotlin   : "2.1.0",
+            mockk           : "1.9.3",
+            robolectric     : "4.3",
+            testCore        : "1.2.0",
+    ]
+
+    annotationProcessors = [
+            dagger        : "com.google.dagger:dagger-compiler:${versions.dagger}",
+            daggerAssisted: "com.squareup.inject:assisted-inject-processor-dagger2:${versions.daggerAssisted}",
+            epoxy         : "com.airbnb.android:epoxy-processor:${versions.epoxy}",
+            lifecycle     : "androidx.lifecycle:lifecycle-compiler:${versions.lifecycle}",
+            moshi         : "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
+            room          : "androidx.room:room-compiler:${versions.room}",
+    ]
+
+    libraries = [
+            appcompat             : "androidx.appcompat:appcompat:${versions.jetpack}",
+            cardview              : "androidx.cardview:cardview:${versions.cardview}",
+            constraintlayout      : "androidx.constraintlayout:constraintlayout:${versions.constraintlayout}",
+            coreKtx               : "androidx.core:core-ktx:${versions.core}",
+            dagger                : "com.google.dagger:dagger:${versions.dagger}",
+            daggerAssisted        : "com.squareup.inject:assisted-inject-annotations-dagger2:${versions.daggerAssisted}",
+            debugDb               : "com.amitshekhar.android:debug-db:${versions.debugDb}",
+            epoxy                 : "com.airbnb.android:epoxy:${versions.epoxy}",
+            espressoIdlingResource: "androidx.test.espresso:espresso-idling-resource:${versions.espresso}",
+            fragmentKtx           : "androidx.fragment:fragment-ktx:${versions.fragment}",
+            fragmentTesting       : "androidx.fragment:fragment-testing:${versions.fragment}",
+            junit                 : "junit:junit:${versions.junit}",
+            koin                  : "org.koin:koin-android:${versions.koin}",
+            kotlin                : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
+            kotlinReflect         : "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
+            lifecycleExtensions   : "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}",
+            lottie                : "com.airbnb.android:lottie:${versions.lottie}",
+            moshi                 : "com.squareup.moshi:moshi:${versions.moshi}",
+            moshiKotlin           : "com.squareup.moshi:moshi-kotlin:${versions.moshi}",
+            navigationFragmentKtx : "androidx.navigation:navigation-fragment-ktx:${versions.navigation}",
+            navigationUiKtx       : "androidx.navigation:navigation-ui-ktx:${versions.navigation}",
+            picasso               : "com.squareup.picasso:picasso:${versions.picasso}",
+            recyclerview          : "androidx.recyclerview:recyclerview:${versions.recyclerview}",
+            retrofit              : "com.squareup.retrofit2:retrofit:${versions.retrofit}",
+            retrofitMoshi         : "com.squareup.retrofit2:converter-moshi:${versions.retrofit}",
+            retrofitRxJava        : "com.squareup.retrofit2:adapter-rxjava2:${versions.retrofit}",
+            roomRxJava            : "androidx.room:room-rxjava2:${versions.room}",
+            roomRuntime           : "androidx.room:room-runtime:${versions.room}",
+            rxAndroid             : "io.reactivex.rxjava2:rxandroid:${versions.rxAndroid}",
+            rxJava                : "io.reactivex.rxjava2:rxjava:${versions.rxJava}",
+            viewModelKtx          : "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.lifecycle}",
+    ]
+
+    instrumentedTestLibraries = [
+            core    : "androidx.test:core:${versions.testCore}",
+            espresso: "androidx.test.espresso:espresso-core:${versions.espresso}",
+            junit   : "androidx.test.ext:junit:${versions.junitExt}"
+    ]
+
+    testLibraries = [
+            junit        : "junit:junit:${versions.junit}",
+            mockito      : "org.mockito:mockito-core:${versions.mockito}",
+            mockitoKotlin: "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitoKotlin}",
+            mockk        : "io.mockk:mockk:${versions.mockk}",
+            roboeletric  : "org.robolectric:robolectric:${versions.robolectric}"
+    ]
+}

--- a/dogs/build.gradle
+++ b/dogs/build.gradle
@@ -1,15 +1,16 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-kapt"
+apply plugin: "kotlin-android-extensions"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         applicationId "com.airbnb.mvrx.dogs"
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "1.0"
     }
@@ -24,23 +25,23 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 
 dependencies {
-    implementation project(':mvrx')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.core:core-ktx:$androidXCoreKtxVersion"
-    implementation 'androidx.cardview:cardview:1.0.0'
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
-    implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
-    implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
-    implementation("com.airbnb.android:epoxy:$epoxyVersion") { exclude group: 'com.android.support' }
-    implementation 'com.squareup.picasso:picasso:2.5.2'
-    implementation 'com.airbnb.android:lottie:3.0.0'
+    implementation libraries.appcompat
+    implementation libraries.cardview
+    implementation libraries.constraintlayout
+    implementation libraries.coreKtx
+    implementation (libraries.epoxy) { exclude group: "com.android.support" }
+    implementation libraries.kotlin
+    implementation libraries.lottie
+    implementation libraries.navigationFragmentKtx
+    implementation libraries.navigationUiKtx
+    implementation libraries.picasso
+    implementation project(":mvrx")
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation project(':testing')
+    testImplementation testLibraries.junit
+    testImplementation project(":testing")
 }

--- a/hellodagger/build.gradle
+++ b/hellodagger/build.gradle
@@ -4,12 +4,13 @@ apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+
     defaultConfig {
         applicationId "com.airbnb.mvrx.helloDagger"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -29,15 +30,15 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 
     signingConfigs {
         debug {
-            storeFile file('debug.keystore')
-            storePassword 'testing'
-            keyAlias 'helloDagger'
-            keyPassword 'testing'
+            storeFile file("debug.keystore")
+            storePassword "testing"
+            keyAlias "helloDagger"
+            keyPassword "testing"
         }
     }
 }
@@ -47,28 +48,27 @@ androidExtensions {
 }
 
 dependencies {
+    kapt annotationProcessors.dagger
+    kapt annotationProcessors.daggerAssisted
+
+    implementation libraries.appcompat
+    implementation libraries.constraintlayout
+    implementation libraries.coreKtx
+    implementation libraries.dagger
+    implementation libraries.daggerAssisted
+    implementation libraries.fragmentKtx
+    implementation libraries.kotlin
+    implementation libraries.rxJava
+    implementation libraries.viewModelKtx
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation project(":mvrx")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    debugImplementation libraries.fragmentTesting
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.core:core-ktx:1.1.0"
-    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0"
-    implementation "androidx.fragment:fragment-ktx:1.2.0-beta02"
+    androidTestImplementation instrumentedTestLibraries.core
+    androidTestImplementation instrumentedTestLibraries.espresso
+    androidTestImplementation instrumentedTestLibraries.junit
 
-    implementation "io.reactivex.rxjava2:rxjava:2.2.12"
-
-    implementation "com.google.dagger:dagger:2.24"
-    kapt "com.google.dagger:dagger-compiler:2.24"
-    implementation "com.squareup.inject:assisted-inject-annotations-dagger2:0.5.0"
-    kapt "com.squareup.inject:assisted-inject-processor-dagger2:0.5.0"
-
-    testImplementation "junit:junit:4.12"
-    testImplementation "io.mockk:mockk:1.9.3"
-    debugImplementation "androidx.fragment:fragment-testing:1.2.0-beta02"
-    androidTestImplementation "androidx.test:core:1.2.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.1"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
+    testImplementation testLibraries.junit
+    testImplementation testLibraries.mockk
 }

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -1,24 +1,25 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 apply plugin: "jacoco"
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 28
-    resourcePrefix 'mvrx_'
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+    resourcePrefix "mvrx_"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
-        consumerProguardFiles 'proguard-rules.pro'
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
+        consumerProguardFiles "proguard-rules.pro"
     }
-    buildToolsVersion "$buildToolsVersion"
+
     lintOptions {
         abortOnError true
         textReport true
-        textOutput 'stdout'
+        textOutput "stdout"
     }
 
     compileOptions {
@@ -27,8 +28,8 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-        test.java.srcDirs += 'src/test/kotlin'
+        main.java.srcDirs += "src/main/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
     }
 
     testOptions {
@@ -52,17 +53,18 @@ jacoco {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
-    kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    api "io.reactivex.rxjava2:rxjava:2.2.8"
+    kapt annotationProcessors.lifecycle
 
-    testImplementation "org.mockito:mockito-core:2.25.1"
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    api libraries.rxAndroid
+    api libraries.rxJava
+
+    implementation libraries.appcompat
+    implementation libraries.kotlin
+    implementation libraries.lifecycleExtensions
+
+    testImplementation testLibraries.junit
+    testImplementation testLibraries.mockito
+    testImplementation testLibraries.roboeletric
 }
 
 task coverage(type: JacocoReport, dependsOn: "testDebugUnitTest") {

--- a/mvrx/src/test/resources/robolectric.properties
+++ b/mvrx/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+# SDK 29 requires Java 9 or newer
+sdk=28

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,35 +1,37 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+
     defaultConfig {
         applicationId "com.airbnb.sample"
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "0.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    buildToolsVersion "$buildToolsVersion"
+
     buildTypes {
         release {
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-project.pro"
         }
     }
 
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()  
     }
 }
 
@@ -38,26 +40,26 @@ androidExtensions {
 }
 
 dependencies {
-    implementation project(':mvrx')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
-    implementation("com.airbnb.android:epoxy:$epoxyVersion") { exclude group: 'com.android.support' }
-    kapt "com.airbnb.android:epoxy-processor:$epoxyVersion"
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation "io.reactivex.rxjava2:rxjava:2.2.8"
-    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    implementation "com.squareup.moshi:moshi:$moshiVersion"
-    implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
-    implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
-    implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
-    implementation "org.koin:koin-android:$koinVersion"
+    kapt annotationProcessors.epoxy
+    kapt annotationProcessors.moshi
 
-    testImplementation 'junit:junit:4.12'
+    implementation libraries.appcompat
+    implementation libraries.constraintlayout
+    implementation (libraries.epoxy) { exclude group: "com.android.support" }
+    implementation libraries.koin
+    implementation libraries.kotlin
+    implementation libraries.lifecycleExtensions
+    implementation libraries.moshi
+    implementation libraries.moshiKotlin
+    implementation libraries.navigationFragmentKtx
+    implementation libraries.navigationUiKtx
+    implementation libraries.recyclerview
+    implementation libraries.retrofit
+    implementation libraries.retrofitMoshi
+    implementation libraries.retrofitRxJava
+    implementation libraries.rxAndroid
+    implementation libraries.rxJava
+    implementation project(":mvrx")
+
+    testImplementation testLibraries.junit
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -31,7 +31,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()  
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,10 @@
-include ':mvrx'
-include ':sample'
-include ':todomvrx'
-include ':testing'
-include ':dogs'
-include ':counter'
-include ':hellodagger'
+// Libraries
+include ":mvrx"
+include ":testing"
+
+// Samples
+include ":counter"
+include ":dogs"
+include ":hellodagger"
+include ":sample"
+include ":todomvrx"

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,25 +1,24 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 28
-    resourcePrefix 'mvrx_'
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+    resourcePrefix "mvrx_"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
-        consumerProguardFiles 'proguard-rules.pro'
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
+        consumerProguardFiles "proguard-rules.pro"
     }
-
-    buildToolsVersion "$buildToolsVersion"
 
     lintOptions {
         abortOnError true
         textReport true
-        textOutput 'stdout'
+        textOutput "stdout"
     }
 
     compileOptions {
@@ -28,12 +27,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-        test.java.srcDirs += 'src/test/kotlin'
+        main.java.srcDirs += "src/main/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
     }
 }
 
@@ -42,11 +41,10 @@ androidExtensions {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
-    implementation project(':mvrx')
-    implementation 'junit:junit:4.12'
+    implementation libraries.appcompat
+    implementation libraries.junit
+    implementation libraries.kotlin
+    implementation libraries.kotlinReflect
+    implementation libraries.rxAndroid
+    implementation project(":mvrx")
 }

--- a/todomvrx/build.gradle
+++ b/todomvrx/build.gradle
@@ -1,28 +1,29 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+
     defaultConfig {
         applicationId "com.airbnb.mvrx.todoapp"
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "0.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    buildToolsVersion "$buildToolsVersion"
 
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 
@@ -31,26 +32,27 @@ androidExtensions {
 }
 
 dependencies {
-    implementation project(':mvrx')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation("androidx.appcompat:appcompat:$appCompatVersion")
-    implementation("androidx.recyclerview:recyclerview:$recyclerViewVersion")
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
-    implementation("com.airbnb.android:epoxy:$epoxyVersion") { exclude group: 'com.android.support' }
-    kapt "com.airbnb.android:epoxy-processor:$epoxyVersion"
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation "io.reactivex.rxjava2:rxjava:2.2.8"
-    implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
-    implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
-    implementation "androidx.room:room-runtime:$roomVersion"
-    implementation "androidx.room:room-rxjava2:$roomVersion"
-    kapt "androidx.room:room-compiler:$roomVersion"
-    implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
-    debugImplementation 'com.amitshekhar.android:debug-db:1.0.4'
+    kapt annotationProcessors.epoxy
+    kapt annotationProcessors.room
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
-    testImplementation project(':testing')
+    implementation libraries.appcompat
+    implementation libraries.constraintlayout
+    implementation (libraries.epoxy) { exclude group: "com.android.support" }
+    implementation libraries.espressoIdlingResource
+    implementation libraries.kotlin
+    implementation libraries.lifecycleExtensions
+    implementation libraries.navigationFragmentKtx
+    implementation libraries.navigationUiKtx
+    implementation libraries.recyclerview
+    implementation libraries.roomRuntime
+    implementation libraries.roomRxJava
+    implementation libraries.rxAndroid
+    implementation libraries.rxJava
+    implementation project(":mvrx")
+
+    debugImplementation libraries.debugDb
+
+    testImplementation testLibraries.junit
+    testImplementation testLibraries.mockitoKotlin
+    testImplementation project(":testing")
 }


### PR DESCRIPTION
About
--------
Create [`dependencies.gradle`][github] file visible by all modules, centralizing libraries versioning, configuration and packages updates.

Build tools version was also updated as follows:

  - Build tools v29.0.3
  - Compile SDK v29
  - Minimum API level v16
  - Target API level v29 (Android Q)
  - Libraries were _ceiled_ to highest version across project modules.

In order to ensure that no behavior was broken due the refactor, libraries updates were moved to pull request #367. Android API was [forced to v28 on Roboeletric tests][roboeletric].

Blocks
---------
  - #366 Update package dependencies to latest stable version

Fixes
-------

  - #363 Centralize Gradle dependencies file

References
---------------

  - [Android Jetpack Versions][jetpack-versions]
  - [Caster.IO: Android Clean Architecture][caster-io]
  - [GitHub: Android Clean Architecture][github]
  - [Google Android - Java 8 Support][google-android]
  - [Google Developers Experts: 19 tips for Gradle in Android projects][gde]
  - [Google I/O 2019 - Build Bigger, Better: Gradle for Large Projects (Google I/O'19)][google-io]
  - [Google Samples - Architecture Blueprints v2][blue-prints]
  - [Stack Overflow - Does Roboeletric require Java 9?][roboeletric]

[jetpack-versions]: https://developer.android.com/jetpack/androidx/versions
[blue-prints]: https://github.com/android/architecture-samples
[caster-io]: https://caster.io/courses/android-clean-architecture
[gde]: https://medium.com/google-developer-experts/19-tips-for-gradle-in-android-projects-2019-edition-11af704eb06e
[github]: https://github.com/hitherejoe/GithubTrending/blob/master/dependencies.gradle
[google-android]: https://developer.android.com/studio/write/java8-support
[google-io]: https://www.youtube.com/watch?v=sQC9-Rj2yLI
[roboeletric]: https://stackoverflow.com/questions/56821193/does-robolectric-require-java-9