### PR TITLE
Added a DelegateMvRxView 

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -12,30 +12,21 @@ import androidx.lifecycle.LifecycleOwner
  */
 abstract class BaseMvRxFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(contentLayoutId), MvRxView {
 
-    private val mvrxViewIdProperty = MvRxViewId()
-    final override val mvrxViewId: String by mvrxViewIdProperty
+    private lateinit var viewDelegate: DelegateMvRxView
+
+    final override val mvrxViewId: String get() = viewDelegate.mvrxViewId
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        mvrxViewIdProperty.restoreFrom(savedInstanceState)
         super.onCreate(savedInstanceState)
+        viewDelegate = DelegateMvRxView(this, ::invalidate)
     }
 
-    /**
-     * Fragments should override the subscriptionLifecycle owner so that subscriptions made after onCreate
-     * are properly disposed as fragments are moved from/to the backstack.
-     */
     override val subscriptionLifecycleOwner: LifecycleOwner
         get() = this.viewLifecycleOwnerLiveData.value ?: this
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        mvrxViewIdProperty.saveTo(outState)
-    }
+    override fun uniqueOnly(customId: String?): UniqueOnly = viewDelegate.uniqueOnly(customId)
 
-    override fun onStart() {
-        super.onStart()
-        // This ensures that invalidate() is called for static screens that don't
-        // subscribe to a ViewModel.
-        postInvalidate()
-    }
+    override fun invalidate() = Unit
+
+    override fun postInvalidate() = viewDelegate.postInvalidate()
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -18,7 +18,11 @@ abstract class BaseMvRxFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewDelegate = DelegateMvRxView(this, ::invalidate)
+        viewDelegate = DelegateMvRxView(
+                savedStateRegistryOwner = this,
+                subscriptionLifecycleOwner = this,
+                onInvalidated = ::invalidate
+        )
     }
 
     override val subscriptionLifecycleOwner: LifecycleOwner

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxFragment.kt
@@ -18,9 +18,8 @@ abstract class BaseMvRxFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewDelegate = DelegateMvRxView(
-                savedStateRegistryOwner = this,
-                subscriptionLifecycleOwner = this,
+        viewDelegate = delegateMvRxView(
+                subscriptionLifecycleOwner = subscriptionLifecycleOwner,
                 onInvalidated = ::invalidate
         )
     }
@@ -29,8 +28,6 @@ abstract class BaseMvRxFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(
         get() = this.viewLifecycleOwnerLiveData.value ?: this
 
     override fun uniqueOnly(customId: String?): UniqueOnly = viewDelegate.uniqueOnly(customId)
-
-    override fun invalidate() = Unit
 
     override fun postInvalidate() = viewDelegate.postInvalidate()
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
@@ -1,0 +1,39 @@
+package com.airbnb.mvrx
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.savedstate.SavedStateRegistryOwner
+
+class DelegateMvRxView(
+        private val owner: SavedStateRegistryOwner,
+        private val onInvalidated: () -> Unit
+) : MvRxView {
+
+    private val name: String = owner.javaClass.name
+    private val mvrxViewIdProperty = MvRxViewId()
+
+    init {
+        owner.savedStateRegistry.registerSavedStateProvider(name) { Bundle().apply { mvrxViewIdProperty.saveTo(this) } }
+        owner.lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) = when (event) {
+                Lifecycle.Event.ON_CREATE -> {
+                    mvrxViewId // Read from the delegate to init the unique id.
+                    mvrxViewIdProperty.restoreFrom(owner.savedStateRegistry.consumeRestoredStateForKey(name))
+                }
+                Lifecycle.Event.ON_DESTROY -> {
+                    source.lifecycle.removeObserver(this)
+                    owner.savedStateRegistry.unregisterSavedStateProvider(name)
+                }
+                else -> Unit
+            }
+        })
+    }
+
+    override val mvrxViewId by mvrxViewIdProperty
+
+    override fun invalidate() = onInvalidated()
+
+    override fun getLifecycle(): Lifecycle = owner.lifecycle
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
@@ -6,6 +6,13 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.savedstate.SavedStateRegistryOwner
 
+/**
+ * A class that allows for delegation of lifecycle and process death semantics to an external
+ * [owner], and the invalidation of the view to a generic [onInvalidated] function.
+ *
+ * This is most useful in cases where inheriting from BaseMvRxFragment is
+ * unfeasible, undesirable, or for composing with a custom view.
+ */
 class DelegateMvRxView(
         private val owner: SavedStateRegistryOwner,
         private val onInvalidated: () -> Unit

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
@@ -8,26 +8,27 @@ import androidx.savedstate.SavedStateRegistryOwner
 
 /**
  * A class that allows for delegation of lifecycle and process death semantics to an external
- * [owner], and the invalidation of the view to a generic [onInvalidated] function.
+ * [savedStateRegistryOwner], and the invalidation of the view to a generic [onInvalidated] function.
  *
  * This is most useful in cases where inheriting from BaseMvRxFragment is
  * unfeasible, undesirable, or for composing with a custom view.
  */
 class DelegateMvRxView(
-        private val owner: SavedStateRegistryOwner,
+        private val savedStateRegistryOwner: SavedStateRegistryOwner,
+        override val subscriptionLifecycleOwner: LifecycleOwner = savedStateRegistryOwner,
         private val onInvalidated: () -> Unit
 ) : MvRxView {
 
-    private val name: String = owner.javaClass.name
+    private val name: String = savedStateRegistryOwner.javaClass.name
     private val mvrxViewIdProperty = MvRxViewId()
 
     init {
-        owner.savedStateRegistry.registerSavedStateProvider(name) { Bundle().apply { mvrxViewIdProperty.saveTo(this) } }
-        owner.lifecycle.addObserver(object : LifecycleEventObserver {
+        savedStateRegistryOwner.savedStateRegistry.registerSavedStateProvider(name) { Bundle().apply { mvrxViewIdProperty.saveTo(this) } }
+        savedStateRegistryOwner.lifecycle.addObserver(object : LifecycleEventObserver {
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) = when (event) {
                 Lifecycle.Event.ON_CREATE -> {
                     mvrxViewId // Read from the delegate to init the unique id.
-                    mvrxViewIdProperty.restoreFrom(owner.savedStateRegistry.consumeRestoredStateForKey(name))
+                    mvrxViewIdProperty.restoreFrom(savedStateRegistryOwner.savedStateRegistry.consumeRestoredStateForKey(name))
                 }
                 Lifecycle.Event.ON_START -> {
                     // This ensures that invalidate() is called for static screens that don't
@@ -36,7 +37,7 @@ class DelegateMvRxView(
                 }
                 Lifecycle.Event.ON_DESTROY -> {
                     source.lifecycle.removeObserver(this)
-                    owner.savedStateRegistry.unregisterSavedStateProvider(name)
+                    savedStateRegistryOwner.savedStateRegistry.unregisterSavedStateProvider(name)
                 }
                 else -> Unit
             }
@@ -47,5 +48,5 @@ class DelegateMvRxView(
 
     override fun invalidate() = onInvalidated()
 
-    override fun getLifecycle(): Lifecycle = owner.lifecycle
+    override fun getLifecycle(): Lifecycle = savedStateRegistryOwner.lifecycle
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
@@ -16,10 +16,10 @@ import androidx.savedstate.SavedStateRegistryOwner
 class DelegateMvRxView(
         private val savedStateRegistryOwner: SavedStateRegistryOwner,
         override val subscriptionLifecycleOwner: LifecycleOwner = savedStateRegistryOwner,
+        private val name: String = savedStateRegistryOwner.javaClass.name,
         private val onInvalidated: () -> Unit
 ) : MvRxView {
 
-    private val name: String = savedStateRegistryOwner.javaClass.name
     private val mvrxViewIdProperty = MvRxViewId()
 
     init {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
@@ -29,6 +29,11 @@ class DelegateMvRxView(
                     mvrxViewId // Read from the delegate to init the unique id.
                     mvrxViewIdProperty.restoreFrom(owner.savedStateRegistry.consumeRestoredStateForKey(name))
                 }
+                Lifecycle.Event.ON_START -> {
+                    // This ensures that invalidate() is called for static screens that don't
+                    // subscribe to a ViewModel.
+                    postInvalidate()
+                }
                 Lifecycle.Event.ON_DESTROY -> {
                     source.lifecycle.removeObserver(this)
                     owner.savedStateRegistry.unregisterSavedStateProvider(name)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/DelegateMvRxView.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx
 
 import android.os.Bundle
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -16,7 +17,7 @@ import androidx.savedstate.SavedStateRegistryOwner
 class DelegateMvRxView(
         private val savedStateRegistryOwner: SavedStateRegistryOwner,
         override val subscriptionLifecycleOwner: LifecycleOwner = savedStateRegistryOwner,
-        private val name: String = savedStateRegistryOwner.javaClass.name,
+        private val name: String,
         private val onInvalidated: () -> Unit
 ) : MvRxView {
 
@@ -50,3 +51,16 @@ class DelegateMvRxView(
 
     override fun getLifecycle(): Lifecycle = savedStateRegistryOwner.lifecycle
 }
+
+/**
+ * Convenience for providing a [DelegateMvRxView] to a [Fragment]
+ */
+fun Fragment.delegateMvRxView(
+        subscriptionLifecycleOwner: LifecycleOwner = this,
+        onInvalidated: () -> Unit
+) = DelegateMvRxView(
+        name = this.javaClass.name,
+        savedStateRegistryOwner = this,
+        subscriptionLifecycleOwner = subscriptionLifecycleOwner,
+        onInvalidated = onInvalidated
+)


### PR DESCRIPTION
A simple Delegate that uses the saved state artifact, for cases where inheriting from `BaseMvRxFragment` is unfeasible, undesirable, or for composing with a custom view. The custom view may choose to grab the `SavedStateRegistryOwner` from either an `Activity` or `Fragment`.

I was able to test this with DogsFragment fine, even across process death. I'm not sure how to contribute this change with tests for this project however, pointers are much appreciated.

There's also the function delegates that will need to be added for `activityViewModel` and the like should this initial change be worthwhile.

Usage was as follows:

```kotlin
class DogsFragment : Fragment(), DogsFragmentHandler {

    private val view = DelegateMvRxView(this, ::invalidate)
    private val viewModel: DogViewModel by activityViewModel(view)
    private lateinit var bindings: DogsFragmentBinding
    private val adapter = DogAdapter(this)

    ...

    private fun invalidate() = withState(viewModel) { state ->
        bindings.state = state
    }
}
```