### PR TITLE
Add value to all Async (load more data use case) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         // ./gradlew clean assemble androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
         // Need to use snapshot version and explicitly include javadoc/sources tasks until
         // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed
-        classpath "com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT"
+        classpath "com.vanniktech:gradle-maven-publish-plugin:0.9.0"
     }
 
     configurations.all {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -38,13 +38,9 @@ sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean, privat
 
 object Uninitialized : Async<Nothing>(complete = false, shouldLoad = true, value = null), Incomplete
 
-class Loading<out T>(value: T? = null) : Async<T>(complete = false, shouldLoad = false, value = value), Incomplete {
-    override fun equals(other: Any?) = other is Loading<*>
+data class Loading<out T>(private val value: T? = null) : Async<T>(complete = false, shouldLoad = false, value = value), Incomplete
 
-    override fun hashCode() = "Loading".hashCode()
-}
-
-class Success<out T>(value: T) : Async<T>(complete = true, shouldLoad = false, value = value) {
+data class Success<out T>(private val value: T) : Async<T>(complete = true, shouldLoad = false, value = value) {
 
     override fun invoke(): T = super.invoke() as T
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -9,14 +9,14 @@ import java.util.Arrays
  * Complete: Success, Fail
  * ShouldLoad: Uninitialized, Fail
  */
-sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean) {
+sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean, private val invokeValue: T?) {
 
     /**
      * Returns the Success value or null.
      *
      * Can be invoked as an operator like: `yourProp()`
      */
-    open operator fun invoke(): T? = null
+    open operator fun invoke(): T? = invokeValue
 
     companion object {
         /**
@@ -36,17 +36,15 @@ sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean) {
     }
 }
 
-object Uninitialized : Async<Nothing>(complete = false, shouldLoad = true), Incomplete
+object Uninitialized : Async<Nothing>(complete = false, shouldLoad = true, invokeValue = null), Incomplete
 
-class Loading<out T> : Async<T>(complete = false, shouldLoad = false), Incomplete {
+class Loading<out T>(value: T? = null) : Async<T>(complete = false, shouldLoad = false, invokeValue = value), Incomplete {
     override fun equals(other: Any?) = other is Loading<*>
 
     override fun hashCode() = "Loading".hashCode()
 }
 
-data class Success<out T>(private val value: T) : Async<T>(complete = true, shouldLoad = false) {
-
-    override operator fun invoke(): T = value
+data class Success<out T>(private val value: T) : Async<T>(complete = true, shouldLoad = false, invokeValue = value) {
 
     /**
      * Optional information about the value.
@@ -62,7 +60,7 @@ data class Success<out T>(private val value: T) : Async<T>(complete = true, shou
     internal var metadata: Any? = null
 }
 
-data class Fail<out T>(val error: Throwable) : Async<T>(complete = true, shouldLoad = true) {
+data class Fail<out T>(val error: Throwable, private val value: T? = null) : Async<T>(complete = true, shouldLoad = true, invokeValue = value) {
     override fun equals(other: Any?): Boolean {
         if (other !is Fail<*>) return false
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -42,7 +42,7 @@ data class Loading<out T>(private val value: T? = null) : Async<T>(complete = fa
 
 data class Success<out T>(private val value: T) : Async<T>(complete = true, shouldLoad = false, value = value) {
 
-    override fun invoke(): T = super.invoke() as T
+    override operator fun invoke(): T = value
 
     /**
      * Optional information about the value.

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -12,7 +12,10 @@ import java.util.Arrays
 sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean, private val value: T?) {
 
     /**
-     * Returns the Success value or null.
+     * Returns the value or null.
+     *
+     * Success always have a value. Loading and Fail can also return a value which is useful for
+     * pagination or progressive data loading.
      *
      * Can be invoked as an operator like: `yourProp()`
      */

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -9,14 +9,14 @@ import java.util.Arrays
  * Complete: Success, Fail
  * ShouldLoad: Uninitialized, Fail
  */
-sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean, private val invokeValue: T?) {
+sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean, private val value: T?) {
 
     /**
      * Returns the Success value or null.
      *
      * Can be invoked as an operator like: `yourProp()`
      */
-    open operator fun invoke(): T? = invokeValue
+    open operator fun invoke(): T? = value
 
     companion object {
         /**
@@ -36,15 +36,17 @@ sealed class Async<out T>(val complete: Boolean, val shouldLoad: Boolean, privat
     }
 }
 
-object Uninitialized : Async<Nothing>(complete = false, shouldLoad = true, invokeValue = null), Incomplete
+object Uninitialized : Async<Nothing>(complete = false, shouldLoad = true, value = null), Incomplete
 
-class Loading<out T>(value: T? = null) : Async<T>(complete = false, shouldLoad = false, invokeValue = value), Incomplete {
+class Loading<out T>(value: T? = null) : Async<T>(complete = false, shouldLoad = false, value = value), Incomplete {
     override fun equals(other: Any?) = other is Loading<*>
 
     override fun hashCode() = "Loading".hashCode()
 }
 
-data class Success<out T>(private val value: T) : Async<T>(complete = true, shouldLoad = false, invokeValue = value) {
+class Success<out T>(value: T) : Async<T>(complete = true, shouldLoad = false, value = value) {
+
+    override fun invoke(): T = super.invoke() as T
 
     /**
      * Optional information about the value.
@@ -60,7 +62,7 @@ data class Success<out T>(private val value: T) : Async<T>(complete = true, shou
     internal var metadata: Any? = null
 }
 
-data class Fail<out T>(val error: Throwable, private val value: T? = null) : Async<T>(complete = true, shouldLoad = true, invokeValue = value) {
+data class Fail<out T>(val error: Throwable, private val value: T? = null) : Async<T>(complete = true, shouldLoad = true, value = value) {
     override fun equals(other: Any?): Boolean {
         if (other !is Fail<*>) return false
 


### PR DESCRIPTION
For "load more data" we currently can't have a `Loading` or `Fail` with some existing data to render. The workaround to make it works is to keep the data separated from the `Async` property (see https://gist.github.com/gpeal/145202421a4e6a1e79c6afeb58b50134).

`Async` already have a `invoke()` method so we can easily solve the issue by adding a `value` in `Loading` and `Fail` classes. 

Example :

Initial load : 
```
setState { 
  copy(
    data = Loading()
  ) 
}
```
Load more page : 
```
setState {
  val currentData = this.data.invoke()
  copy(
    data = Loading(currentData)
  ) 
}
```
