### PR TITLE
Make BaseMvRxViewModel not extend ViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Version 2.0.0
+### Breaking Changes
+- BaseMvRxViewModel no longer extends Jetpack ViewModel
+- viewModelScope is now a protected property on BaseMvRxViewModel, not the Jetpack extension function for ViewModel.
+
 ## Version 1.4.0
 - Remove Kotlin-Reflect entirely (#334)
 - Remove extra proguard dependency (#310)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -41,7 +42,8 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     stateStoreOveride: MvRxStateStore<S>? = null
 ) {
     private val debugMode = if (MvRxTestOverrides.FORCE_DEBUG == null) debugMode else MvRxTestOverrides.FORCE_DEBUG
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    @VisibleForTesting
+    internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val stateStore = stateStoreOveride ?: CoroutinesStateStore(initialState, scope)
 
     private val tag by lazy { javaClass.simpleName }
@@ -93,6 +95,7 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
     }
 
     fun onCleared() {
+        scope.cancel()
         disposables.dispose()
         lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
     }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxFactory.kt
@@ -41,7 +41,7 @@ private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
     viewModelContext: ViewModelContext,
     stateRestorer: (S) -> S,
     initialStateFactory: MvRxStateFactory<VM, S>
-): VM {
+): MvRxViewModelWrapper<VM, S> {
     val initialState = initialStateFactory.createInitialState(viewModelClass, stateClass, viewModelContext, stateRestorer)
     val factoryViewModel = viewModelClass.factoryCompanion()?.let { factoryClass ->
         try {
@@ -53,8 +53,7 @@ private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
                 .invoke(null, viewModelContext, initialState) as VM?
         }
     }
-    val viewModel = factoryViewModel ?: createDefaultViewModel(viewModelClass, initialState)
-    return requireNotNull(viewModel) {
+    val viewModel = requireNotNull(factoryViewModel ?: createDefaultViewModel(viewModelClass, initialState)) {
         if (viewModelClass.constructors.firstOrNull()?.parameterTypes?.size?.let { it > 1 } == true) {
             "${viewModelClass.simpleName} takes dependencies other than initialState. " +
                 "It must have companion object implementing ${MvRxViewModelFactory::class.java.simpleName} " +
@@ -64,6 +63,7 @@ private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
                 "single non-optional parameter that takes initial state of ${stateClass.simpleName}."
         }
     }
+    return MvRxViewModelWrapper(viewModel)
 }
 
 @Suppress("UNCHECKED_CAST", "NestedBlockDepth")

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -49,31 +49,32 @@ object MvRxViewModelProvider {
 
         val restoredContext = stateRestorer?.viewModelContext ?: viewModelContext
 
-        val viewModel = ViewModelProvider(
-            viewModelContext.owner,
-            MvRxFactory(
-                viewModelClass,
-                stateClass,
-                restoredContext,
-                key,
-                stateRestorer?.toRestoredState,
-                forExistingViewModel,
-                initialStateFactory
-            )
-        ).get(key, viewModelClass)
+        @Suppress("UNCHECKED_CAST")
+        val viewModel: MvRxViewModelWrapper<VM, S> = ViewModelProvider(
+                viewModelContext.owner,
+                MvRxFactory(
+                        viewModelClass,
+                        stateClass,
+                        restoredContext,
+                        key,
+                        stateRestorer?.toRestoredState,
+                        forExistingViewModel,
+                        initialStateFactory
+                )
+        ).get(key, MvRxViewModelWrapper::class.java) as MvRxViewModelWrapper<VM, S>
 
         try {
             // Save the view model's state to the bundle so that it can be used to recreate
             // state across system initiated process death.
             viewModelContext.savedStateRegistry.registerSavedStateProvider(key) {
-                viewModel.getSavedStateBundle(restoredContext.args)
+                viewModel.viewModel.getSavedStateBundle(restoredContext.args)
             }
         } catch (e: IllegalArgumentException) {
             // The view model was already registered with the context. We only want the initial
             // fragment that creates the view model to register with the saved state registry so
             // that it saves the correct arguments.
         }
-        return viewModel
+        return viewModel.viewModel
     }
 
     private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> VM.getSavedStateBundle(

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelWrapper.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelWrapper.kt
@@ -1,0 +1,10 @@
+package com.airbnb.mvrx
+
+import androidx.lifecycle.ViewModel
+
+class MvRxViewModelWrapper<VM : BaseMvRxViewModel<S>, S : MvRxState>(val viewModel: VM) : ViewModel() {
+    override fun onCleared() {
+        super.onCleared()
+        viewModel.onCleared()
+    }
+}

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseViewModelTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseViewModelTest.kt
@@ -6,7 +6,10 @@ import org.junit.Test
 
 class BaseViewModelTest : BaseTest() {
     data class TestState(val foo: Int = 5) : MvRxState
-    class TestViewModel : BaseMvRxViewModel<TestState>(TestState(), debugMode = false)
+    class TestViewModel : BaseMvRxViewModel<TestState>(TestState(), debugMode = false) {
+        // Make viewModelScope public
+        val scope = viewModelScope
+    }
 
     @Test
     fun testScopeIsCancelled() {

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseViewModelTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseViewModelTest.kt
@@ -1,0 +1,17 @@
+package com.airbnb.mvrx
+
+import kotlinx.coroutines.isActive
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class BaseViewModelTest : BaseTest() {
+    data class TestState(val foo: Int = 5) : MvRxState
+    class TestViewModel : BaseMvRxViewModel<TestState>(TestState(), debugMode = false)
+
+    @Test
+    fun testScopeIsCancelled() {
+        val viewModel = TestViewModel()
+        viewModel.onCleared()
+        assertFalse(viewModel.scope.isActive)
+    }
+}

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/InterViewModelSubscriberTest.kt
@@ -258,16 +258,6 @@ class InnerViewModelSubscriberTest : BaseTest() {
     }
 
     @Test
-    fun testChangesAfterOuterCleared() {
-        outerViewModel.triggerCleared()
-        outerViewModel.setFoo(1)
-        outerViewModel.setAsync(Success("Hello World"))
-        assertEquals(1, innerViewModel.subscribeCalled)
-        assertEquals(0, innerViewModel.onSuccessCalled)
-        assertEquals(0, innerViewModel.onFailCalled)
-    }
-
-    @Test
     fun testSelectSubscribe2() {
         var callCount = 0
         innerViewModel.subscribeToTwoProps(outerViewModel) { callCount++ }


### PR DESCRIPTION
It would be amazing if we can get BaseMvRxViewModel to be a pojo. That would enable testing on the jvm without robolectric and a potential path to Kotlin Multiplatform.

I was just poking around at what this would look like and it turned out to be fairly simple.

The next hurdle is replacing the inter-vm subscriptions which use Lifecycle with something else but that should be doable.

This PR builds on https://github.com/airbnb/MvRx/pull/347

@ZacSweers