### PR TITLE
Use shared dispatcher for flushing queues instead of single thread per VM

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
@@ -68,12 +68,7 @@ class CoroutinesStateStore<S : MvRxState>(
     private fun setupTriggerFlushQueues(scope: CoroutineScope) {
         if (MvRxTestOverrides.FORCE_SYNCHRONOUS_STATE_STORES) return
 
-        val executor = Executors.newSingleThreadExecutor()
-        scope.coroutineContext[Job]!!.invokeOnCompletion {
-            executor.shutdownNow()
-        }
-
-        scope.launch(executor.asCoroutineDispatcher()) {
+        scope.launch(flushDispatcher) {
             while (isActive) {
                 flushQueuesOnce()
             }
@@ -124,5 +119,9 @@ class CoroutinesStateStore<S : MvRxState>(
         if (MvRxTestOverrides.FORCE_SYNCHRONOUS_STATE_STORES) {
             runBlocking { flushQueuesOnce() }
         }
+    }
+
+    companion object {
+        private val flushDispatcher = Executors.newCachedThreadPool().asCoroutineDispatcher()
     }
 }


### PR DESCRIPTION
This PR replaces single thread dispatcher per VM with shared thread pool. 
It will reuse existing threads if possible or will spawn one more thread if necessary. As a result, less thread will be used, and threads from cleared VMs will be reused. 

`newCachedThreadPool` docs: 

>Creates a thread pool that creates new threads as needed, but
     will reuse previously constructed threads when they are
     available.  **These pools will typically improve the performance
     of programs that execute many short-lived asynchronous tasks.**
     Calls to {@code execute} will reuse previously constructed
     threads if available. If no existing thread is available, a new
     thread will be created and added to the pool. Threads that have
     not been used for sixty seconds are terminated and removed from
     the cache. Thus, a pool that remains idle for long enough will
     not consume any resources.

I could add some benchmarks for the different scenarios. Is there a common pattern/example in this repo for such benchmarks?

Also cached thread pool can be configured with non-default params:
minThreadCount (currently 0)
maxThreadCount (currently inf)
keepAliveTime (currently 60s)

based on #347 