### PR TITLE
[2.0] Make BaseMvRxViewModel not extend ViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Previously, setState would only be prioritized at that nesting level so it would
 Now, it will run:
 [W1, S1, S2, S3, W2]
 - If your MvRxView/Fragment does not use any ViewModels, invalidate() will NOT be called in onStart(). In MvRx 1.x, invalidate would be called even if MvRx was not used at all. If you would like to maintain the original behavior, call `postInvalidate()` from onStart in your base Fragment class.
+- BaseMvRxViewModel no longer extends Jetpack ViewModel
+- viewModelScope is now a property on BaseMvRxViewModel, not the Jetpack extension function for ViewModel. Functionally, this is the same but the previous viewModelScope import will now be unused.
 
 ## Version 1.4.0
 - Remove Kotlin-Reflect entirely (#334)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxFactory.kt
@@ -41,7 +41,7 @@ private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
     viewModelContext: ViewModelContext,
     stateRestorer: (S) -> S,
     initialStateFactory: MvRxStateFactory<VM, S>
-): VM {
+): MvRxViewModelWrapper<VM, S> {
     val initialState = initialStateFactory.createInitialState(viewModelClass, stateClass, viewModelContext, stateRestorer)
     val factoryViewModel = viewModelClass.factoryCompanion()?.let { factoryClass ->
         try {
@@ -53,8 +53,7 @@ private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
                 .invoke(null, viewModelContext, initialState) as VM?
         }
     }
-    val viewModel = factoryViewModel ?: createDefaultViewModel(viewModelClass, initialState)
-    return requireNotNull(viewModel) {
+    val viewModel = requireNotNull(factoryViewModel ?: createDefaultViewModel(viewModelClass, initialState)) {
         if (viewModelClass.constructors.firstOrNull()?.parameterTypes?.size?.let { it > 1 } == true) {
             "${viewModelClass.simpleName} takes dependencies other than initialState. " +
                 "It must have companion object implementing ${MvRxViewModelFactory::class.java.simpleName} " +
@@ -64,6 +63,7 @@ private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> createViewModel(
                 "single non-optional parameter that takes initial state of ${stateClass.simpleName}."
         }
     }
+    return MvRxViewModelWrapper(viewModel)
 }
 
 @Suppress("UNCHECKED_CAST", "NestedBlockDepth")

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelProvider.kt
@@ -49,31 +49,32 @@ object MvRxViewModelProvider {
 
         val restoredContext = stateRestorer?.viewModelContext ?: viewModelContext
 
-        val viewModel = ViewModelProvider(
-            viewModelContext.owner,
-            MvRxFactory(
-                viewModelClass,
-                stateClass,
-                restoredContext,
-                key,
-                stateRestorer?.toRestoredState,
-                forExistingViewModel,
-                initialStateFactory
-            )
-        ).get(key, viewModelClass)
+        @Suppress("UNCHECKED_CAST")
+        val viewModel: MvRxViewModelWrapper<VM, S> = ViewModelProvider(
+                viewModelContext.owner,
+                MvRxFactory(
+                        viewModelClass,
+                        stateClass,
+                        restoredContext,
+                        key,
+                        stateRestorer?.toRestoredState,
+                        forExistingViewModel,
+                        initialStateFactory
+                )
+        ).get(key, MvRxViewModelWrapper::class.java) as MvRxViewModelWrapper<VM, S>
 
         try {
             // Save the view model's state to the bundle so that it can be used to recreate
             // state across system initiated process death.
             viewModelContext.savedStateRegistry.registerSavedStateProvider(key) {
-                viewModel.getSavedStateBundle(restoredContext.args)
+                viewModel.viewModel.getSavedStateBundle(restoredContext.args)
             }
         } catch (e: IllegalArgumentException) {
             // The view model was already registered with the context. We only want the initial
             // fragment that creates the view model to register with the saved state registry so
             // that it saves the correct arguments.
         }
-        return viewModel
+        return viewModel.viewModel
     }
 
     private fun <VM : BaseMvRxViewModel<S>, S : MvRxState> VM.getSavedStateBundle(

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelWrapper.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxViewModelWrapper.kt
@@ -1,0 +1,10 @@
+package com.airbnb.mvrx
+
+import androidx.lifecycle.ViewModel
+
+class MvRxViewModelWrapper<VM : BaseMvRxViewModel<S>, S : MvRxState>(val viewModel: VM) : ViewModel() {
+    override fun onCleared() {
+        super.onCleared()
+        viewModel.onCleared()
+    }
+}

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseViewModelTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseViewModelTest.kt
@@ -1,0 +1,20 @@
+package com.airbnb.mvrx
+
+import kotlinx.coroutines.isActive
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class BaseViewModelTest : BaseTest() {
+    data class TestState(val foo: Int = 5) : MvRxState
+    class TestViewModel : BaseMvRxViewModel<TestState>(TestState(), debugMode = false) {
+        // Make viewModelScope public
+        val scope = viewModelScope
+    }
+
+    @Test
+    fun testScopeIsCancelled() {
+        val viewModel = TestViewModel()
+        viewModel.onCleared()
+        assertFalse(viewModel.scope.isActive)
+    }
+}


### PR DESCRIPTION
https://github.com/airbnb/MvRx/pull/385 but rebased and retargeted to `release/2.0.0`

It would be amazing if we can get BaseMvRxViewModel to be a pojo. That would enable testing on the jvm without robolectric and a potential path to Kotlin Multiplatform.

I was just poking around at what this would look like and it turned out to be fairly simple.

The next hurdle is replacing the inter-vm subscriptions which use Lifecycle with something else but that should be doable.