### PR TITLE
Remove kapt from MvRx

### DIFF
--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -3,7 +3,6 @@ import com.airbnb.mvrx.JacocoReportTask
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
-apply plugin: "kotlin-kapt"
 apply plugin: "jacoco"
 apply plugin: "com.vanniktech.maven.publish"
 
@@ -31,13 +30,12 @@ jacoco {
 }
 
 dependencies {
-    kapt AnnotationProcessors.lifecycle
-
     api Libraries.rxAndroid
     api Libraries.rxJava
     api Libraries.kotlinCoroutines
 
     implementation Libraries.appcompat
+    implementation Libraries.lifecycleCommon
     implementation Libraries.viewModelKtx
     implementation Libraries.runtimeKtx
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -3,11 +3,10 @@ package com.airbnb.mvrx
 import android.util.Log
 import androidx.annotation.CallSuper
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.MvRxTestOverrides.FORCE_DISABLE_LIFECYCLE_AWARE_OBSERVER
@@ -739,15 +738,13 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
 
     @Suppress("EXPERIMENTAL_API_USAGE")
     private fun <T> Flow<T>.assertOneActiveSubscription(owner: LifecycleOwner, deliveryMode: UniqueOnly): Flow<T> {
-        val observer = object : LifecycleObserver {
-            @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-            fun onCreate() {
+        val observer = object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
                 if (activeSubscriptions.contains(deliveryMode.subscriptionId)) error(duplicateSubscriptionMessage(deliveryMode))
                 activeSubscriptions += deliveryMode.subscriptionId
             }
 
-            @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-            fun onDestroy() {
+            override fun onDestroy(owner: LifecycleOwner) {
                 activeSubscriptions.remove(deliveryMode.subscriptionId)
             }
         }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareFlow.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MvRxLifecycleAwareFlow.kt
@@ -2,10 +2,8 @@
 
 package com.airbnb.mvrx
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combineTransform
@@ -16,14 +14,12 @@ import kotlinx.coroutines.flow.combineTransform
  */
 fun <T : Any> Flow<T>.flowWhenStarted(owner: LifecycleOwner): Flow<T> {
     val startedFlow = MutableStateFlow(false)
-    owner.lifecycle.addObserver(object : LifecycleObserver {
-        @OnLifecycleEvent(Lifecycle.Event.ON_START)
-        fun onStart() {
+    owner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
             startedFlow.value = true
         }
 
-        @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-        fun onStop() {
+        override fun onStop(owner: LifecycleOwner) {
             startedFlow.value = false
         }
     })

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
@@ -3,10 +3,8 @@
 package com.airbnb.mvrx
 
 import androidx.annotation.RestrictTo
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 import java.io.Serializable
 
 private object UninitializedValue
@@ -25,9 +23,8 @@ class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: 
     private val lock = this
 
     init {
-        owner.lifecycle.addObserver(object : LifecycleObserver {
-            @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-            fun onStart() {
+        owner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
                 if (!isInitialized()) value
                 owner.lifecycle.removeObserver(this)
             }


### PR DESCRIPTION
Switches from kapt lifecycle observers to java 8 DefaultLifecycleObserver
https://developer.android.com/reference/androidx/lifecycle/Lifecycle

@denis-bezrukov