### PR TITLE
Fix race condition between subscriber thread and flush thread [2]

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -52,11 +53,9 @@ class CoroutinesStateStore<S : MvRxState>(
             val (initialState, subscription) =  updateMutex.withLock {
                 state to stateChannel.openSubscription()
             }
-            try {
+            subscription.consume {
                 emit(initialState)
-                emitAll(subscription)
-            } finally {
-                subscription.cancel()
+                emitAll(this)
             }
         }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
@@ -50,7 +50,7 @@ class CoroutinesStateStore<S : MvRxState>(
      */
     override val flow: Flow<S>
         get() = flow {
-            val (initialState, subscription) =  updateMutex.withLock {
+            val (initialState, subscription) = updateMutex.withLock {
                 state to stateChannel.openSubscription()
             }
             subscription.consume {

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/CoroutineStateStoreReplayTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/CoroutineStateStoreReplayTest.kt
@@ -69,7 +69,7 @@ class CoroutineStateStoreReplayTest {
 
     /**
      * Tests that cancellation during first emit in CoroutinesStateStore.flow doesn't block other collectors forever
-     * Will fail without finally block in
+     * Will fail if stateChannel subscription will be collected without finally block in CoroutinesStateStore.flow builder
      */
     @Test(timeout = 10_000)
     fun testProperCancellation() = runBlocking {


### PR DESCRIPTION
This is a follow up PR for #414 
Fixed unfinished comment and close channel idiomatically
channel.consume does the same as try-finally, but closes the channel with proper error (if it was)