### PR TITLE
Fix failing data class check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change log
+## Version 1.5.1
+- Fix incorrectly failing debug assertions for state class being a data class when a property has internal visibility
+
 ## Version 1.5.0
 - Add an optional nullable value to all Async classes (#383)
 - Update various dependencies

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/MvRxMutabilityHelperKtTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/MvRxMutabilityHelperKtTest.kt
@@ -1,0 +1,19 @@
+package com.airbnb.mvrx
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MvRxMutabilityHelperKtTest {
+
+    @Test
+    fun isData() {
+        assertTrue(TestDataClass::class.java.isData)
+        assertFalse(String::class.java.isData)
+    }
+
+    data class TestDataClass(
+            internal val foo: Int
+    )
+}
+

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/PersistedStateTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/PersistedStateTest.kt
@@ -32,6 +32,17 @@ class PersistedStateTest : BaseTest() {
         assertEquals(5, newState.count)
     }
 
+    data class StateWithInternalVal(@PersistState internal val count: Int = 5) : MvRxState
+
+    @Test
+    fun saveInternalInt() {
+        // internal properties in data classes have different method names generated for them,
+        // and our custom copy function needs to handle that.
+        val bundle = PersistStateTestHelpers.persistState(StateWithInternalVal())
+        val newState = PersistStateTestHelpers.restorePersistedState(bundle, StateWithInternalVal())
+        assertEquals(5, newState.count)
+    }
+
     @Test(expected = IllegalStateException::class)
     fun validatesMissingKeyInBundle() {
         data class State(@PersistState val count: Int = 5) : MvRxState


### PR DESCRIPTION
I noticed that the immutability check for data classes was incorrectly failing in our project. After investigating I realized that internal properties have a componentN function name with a `$module_name` suffix. I fixed the check for data classes, and also had to fix the copy function for restoring state.

I've made a 1.5.1 release for this already