### PR TITLE
[2.0] Add BaseMvRxViewModel subscribe for backwards compatiblity.

### DIFF
--- a/mvrx-rxjava2/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
+++ b/mvrx-rxjava2/src/main/kotlin/com/airbnb/mvrx/BaseMvRxViewModel.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx
 
 import android.util.Log
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -145,6 +146,18 @@ abstract class BaseMvRxViewModel<S : MvRxState>(
      * For ViewModels that want to subscribe to itself.
      */
     protected fun subscribe(subscriber: (S) -> Unit): Disposable = onEachInternal(null, action = { subscriber(it) }).toDisposable()
+
+    /**
+     * Subscribe to state when this LifecycleOwner is started.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    fun subscribe(
+        owner: LifecycleOwner,
+        deliveryMode: DeliveryMode = RedeliverOnStart,
+        subscriber: (S) -> Unit
+    ): Disposable {
+        return onEachInternal(owner, deliveryMode, { subscriber(it) }).toDisposable()
+    }
 
     /**
      * For ViewModels that want to subscribe to another ViewModel.


### PR DESCRIPTION
While testing the 2.0 upgrade at Tonal, it looks like we're using this restricted API so to improve backwards compatiblity, let's re-add it.

Oddly, there is no IDE warning even though the inspection is set to error for us.

@elihart With this change, I think we can start testing this at Tonal in production.