### PR TITLE
Force dispatch onEach/selectSubscribe coroutine

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -533,6 +533,9 @@ abstract class MavericksViewModel<S : MvRxState>(
         }
         val scope = lifecycleOwner?.lifecycleScope ?: viewModelScope
         return scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            // Use yield to ensure flow collect coroutine is dispatched rather than invoked immediately.
+            // This is necessary when Dispatchers.Main.immediate is used in scope.
+            // Coroutine is launched with start = CoroutineStart.UNDISPATCHED to perform dispatch only once.
             yield()
             flow.collectLatest(action)
         }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.yield
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KProperty1
@@ -510,6 +512,7 @@ abstract class MavericksViewModel<S : MvRxState>(
         }
     }
 
+    @Suppress("EXPERIMENTAL_API_USAGE")
     private fun <T : Any> Flow<T>.resolveSubscription(
         lifecycleOwner: LifecycleOwner? = null,
         deliveryMode: DeliveryMode,
@@ -529,7 +532,8 @@ abstract class MavericksViewModel<S : MvRxState>(
             flowWhenStarted(lifecycleOwner)
         }
         val scope = lifecycleOwner?.lifecycleScope ?: viewModelScope
-        return scope.launch {
+        return scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            yield()
             flow.collectLatest(action)
         }
     }


### PR DESCRIPTION
It fixes behavior change introduced in 2.0.
Since 2.0 selectSubscribe/onEach/invalidate is invoked (first time) with onStart in the stacktrace because we use Dispatchers.Main.immediate in VM scope. It's ok in most of the cases, but in tricky cases like navigation in may lead to issues. 

The fix helps to dispatch coroutine even if  isDispatchNeeded = true in scope's dispatcher. 