### PR TITLE
Improve performance of lifecycle aware flow

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksLifecycleAwareFlow.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksLifecycleAwareFlow.kt
@@ -6,19 +6,51 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combineTransform
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlinx.coroutines.selects.select
 
 /**
  * Emits values from the source flow only when the owner is started.
  * When the owner transitions to started, the most recent value will be emitted.
  */
-fun <T : Any> Flow<T>.flowWhenStarted(owner: LifecycleOwner): Flow<T> {
-    val startedChannel = startedChannel(owner.lifecycle)
-    return startedChannel.consumeAsFlow().combineTransform(this.onCompletion { startedChannel.cancel() }) { started, value ->
-        if (started) emit(value)
+fun <T : Any> Flow<T>.flowWhenStarted(owner: LifecycleOwner): Flow<T> = flow {
+
+    coroutineScope {
+        val startedChannel = startedChannel(owner.lifecycle)
+        val flowChannel = produce { collect { send(it) } }
+
+        val transform: suspend (Boolean, T) -> Unit = { started, value ->
+            if (started) {
+                emit(value)
+            }
+        }
+
+        var started: Boolean? = null
+        var flowValue: T? = null
+        var isClosed = false
+
+        while (!isClosed) {
+            select<Unit> {
+                onReceive(startedChannel, { isClosed = true }) {
+                    started = it
+                    if (flowValue != null) {
+                        transform(it, flowValue as T)
+                    }
+                }
+                onReceive(flowChannel, { isClosed = true }) {
+                    flowValue = it
+                    if (started !== null) {
+                        transform(started as Boolean, it)
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -42,4 +74,16 @@ private fun startedChannel(owner: Lifecycle): Channel<Boolean> {
         owner.removeObserver(observer)
     }
     return channel
+}
+
+private inline fun <T : Any> SelectBuilder<Unit>.onReceive(
+    channel: ReceiveChannel<T>,
+    crossinline onClosed: () -> Unit,
+    noinline onReceive: suspend (value: T) -> Unit
+) {
+    @Suppress("DEPRECATION")
+    channel.onReceiveOrNull {
+        if (it === null) onClosed()
+        else onReceive(it)
+    }
 }


### PR DESCRIPTION
we noticed a performance regression when main thread is busy
after reviewing `combineTransform` implementation I found that it converts flows to _fair channels_. Fair channel uses `yield` each time in fast-path offer, that means it dispatches coroutine per each element. 

In this PR I rewrote `flowWhenStarted` by forking combineTransform implementation and adopting it for us. It includes two changes: 
1. use non-fair channels
2. end flow if startedFlow/vm.stateflow is ended (combineTransform waited for completion of both flows, so we used `this.onCompletion { startedChannel.cancel() }`)

I also want to cover this with more tests for
a) prevent this regression in future
b) ensure nothing was broken due change to non-fair channel
But operator is ready for review. 