### PR TITLE
Fix tests in mvrx-rxjava2 artifact

### DIFF
--- a/mvrx-rxjava2/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
+++ b/mvrx-rxjava2/src/test/kotlin/com/airbnb/mvrx/ViewModelSubscriberTest.kt
@@ -778,14 +778,14 @@ class ViewModelSubscriberTest : BaseTest() {
     fun testCancelledIfOwnerDestroyed() {
         val job = viewModel.onEachInternal(owner) {}
         owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-        assertTrue(job.isCancelled)
+        assertTrue(job.isCompleted)
     }
 
     @Test
     fun testCancelledIfViewModelCleared() = runBlocking {
         val job = viewModel.onEachInternal(owner) {}
         viewModel.triggerCleared()
-        assertTrue(job.isCancelled)
+        assertTrue(job.isCompleted)
     }
 
     @Test


### PR DESCRIPTION
@gpeal @elihart 

when I was working on #444 I ran tests only on `:mvrx` module 🙁 . PR checks didn't run (they doesn't run for external contributors) so we didn't notice this.. 
In this PR I ran the following commands locally:
`gradlew testDebugUnitTest`, `gradlew detekt`, `gradlew assembleDebug`