### PR TITLE
StateStore StrictMode prototype

### DIFF
--- a/docs/debug-checks.md
+++ b/docs/debug-checks.md
@@ -7,3 +7,17 @@ MvRx has a debug mode that enables some validation checks. When you integrate Mv
 * State types are not one of: ArrayList, SparseArray, LongSparseArray, SparseArrayCompat, ArrayMap, and HashMap.
 * State class visibility is public so it can be created and restored
 * Each instance of your State is not mutated once it is set on the viewmodel
+
+### Avoid slow operations in `withState`/`setState`
+As all `withState`/`setState` blocks are processed sequentially, it's highly recommended to avoid slow calls inside these blocks (blocking IO/cpu consuming calls). You can use Android [StrictMode](https://developer.android.com/reference/android/os/StrictMode) to detect such calls. StrictMode.ThreadPolicy can be injected into `MavericksViewModelConfigFactory.storeContextOverride`:
+```
+val threadPolicy = StrictMode.ThreadPolicy.Builder()
+    .detectNetwork()
+    .penaltyDialog()
+    .build()
+
+Mavericks.viewModelConfigFactory = MavericksViewModelConfigFactory(
+    this,
+    storeContextOverride = if (isDebuggable()) threadPolicy.asContextElement() else EmptyCoroutineContext
+)
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,6 +37,8 @@ It is fine to use the default implementation of `MavericksViewModelConfigFactory
 
 This checks whether your application was built as a debuggable build, and if so will enable the debug checks.
 
+You also may override `MavericksViewModelConfigFactory.storeContextOverride` that StateStore uses internally (see [threading](https://github.com/airbnb/Mavericks/wiki#threading-in-mvrx) and [debug-checks](https://github.com/airbnb/Mavericks/wiki#debug-checks) for more details)
+
 #### [Optional] Configuration with Mocking Support
 If you would like to take advantage of [Mavericks's mocking system](https://github.com/airbnb/Mavericks/wiki/Mavericks-Mocking-System) at all you should instead initialize the global settings via the `MavericksMocks` object in your application's initialization.
 ```kotlin

--- a/docs/threading.md
+++ b/docs/threading.md
@@ -39,3 +39,5 @@ fun invalidate() = withState(viewModel) { state ->
     // This block is run immediately and returns the final expression of this lambda.
 }
 ```
+
+By default Mavericks creates a shared dispatcher for processing `withState`/`setState` queue. You can set your own dispatcher (e.g. `Dispatchers.Default`) by injecting it into `MavericksViewModelConfigFactory.storeContextOverride`

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/AndroidStrictModeExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/AndroidStrictModeExtensions.kt
@@ -1,0 +1,23 @@
+package com.airbnb.mvrx
+
+import android.os.StrictMode
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+fun StrictMode.ThreadPolicy.asContextElement(): CoroutineContext.Element = ThreadPolicyElement(this)
+
+private class ThreadPolicyElement(val policy: StrictMode.ThreadPolicy) : ThreadContextElement<StrictMode.ThreadPolicy>,
+    AbstractCoroutineContextElement(ThreadPolicyElement) {
+    companion object Key : CoroutineContext.Key<ThreadPolicyElement>
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: StrictMode.ThreadPolicy) {
+        StrictMode.setThreadPolicy(oldState)
+    }
+
+    override fun updateThreadContext(context: CoroutineContext): StrictMode.ThreadPolicy {
+        val oldPolicy = StrictMode.getThreadPolicy()
+        StrictMode.setThreadPolicy(policy)
+        return oldPolicy
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/AndroidStrictModeExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/AndroidStrictModeExtensions.kt
@@ -5,6 +5,10 @@ import kotlinx.coroutines.ThreadContextElement
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Wraps [StrictMode.ThreadPolicy] into [ThreadContextElement]. The resulting [ThreadContextElement] maintains the given policy
+ * for coroutine regardless of the actual thread its is resumed on.
+ */
 fun StrictMode.ThreadPolicy.asContextElement(): CoroutineContext.Element = ThreadPolicyElement(this)
 
 private class ThreadPolicyElement(val policy: StrictMode.ThreadPolicy) : ThreadContextElement<StrictMode.ThreadPolicy>,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/CoroutinesStateStore.kt
@@ -16,11 +16,14 @@ import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 class CoroutinesStateStore<S : MavericksState>(
     initialState: S,
-    private val scope: CoroutineScope
+    private val scope: CoroutineScope,
+    private val contextOverride: CoroutineContext = EmptyCoroutineContext
 ) : MavericksStateStore<S> {
 
     private val setStateChannel = Channel<S.() -> S>(capacity = Channel.UNLIMITED)
@@ -72,7 +75,7 @@ class CoroutinesStateStore<S : MavericksState>(
     private fun setupTriggerFlushQueues(scope: CoroutineScope) {
         if (MavericksTestOverrides.FORCE_SYNCHRONOUS_STATE_STORES) return
 
-        scope.launch(flushDispatcher) {
+        scope.launch(flushDispatcher + contextOverride) {
             try {
                 while (isActive) {
                     flushQueuesOnce()

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Factory for providing the [MavericksViewModelConfig] for each new ViewModel that is created.
@@ -28,13 +29,18 @@ open class MavericksViewModelConfigFactory(
      * Provide a default context for viewModelScope. It will be added after [SupervisorJob]
      * and [Dispatchers.Main.immediate].
      */
-    val contextOverride: CoroutineContext? = null
+    val contextOverride: CoroutineContext = EmptyCoroutineContext,
+    val storeContextOverride: CoroutineContext = EmptyCoroutineContext
 ) {
 
     /**
      * Sets [debugMode] depending on whether the app was built with the Debuggable flag enabled.
      */
-    constructor(context: Context, contextOverride: CoroutineContext? = null) : this(context.isDebuggable(), contextOverride)
+    constructor(
+        context: Context,
+        contextOverride: CoroutineContext = EmptyCoroutineContext,
+        storeContextOverride: CoroutineContext = EmptyCoroutineContext
+    ) : this(context.isDebuggable(), contextOverride, storeContextOverride)
 
     private val onConfigProvidedListener =
         mutableListOf<(MavericksViewModel<*>, MavericksViewModelConfig<*>) -> Unit>()
@@ -61,7 +67,7 @@ open class MavericksViewModelConfigFactory(
         initialState: S
     ): MavericksViewModelConfig<S> {
         val scope = coroutineScope()
-        return object : MavericksViewModelConfig<S>(debugMode, CoroutinesStateStore(initialState, scope), scope) {
+        return object : MavericksViewModelConfig<S>(debugMode, CoroutinesStateStore(initialState, scope, storeContextOverride), scope) {
             override fun <S : MavericksState> onExecute(viewModel: MavericksViewModel<S>): BlockExecutions {
                 return BlockExecutions.No
             }
@@ -82,8 +88,6 @@ open class MavericksViewModelConfigFactory(
     fun removeOnConfigProvidedListener(callback: (MavericksViewModel<*>, MavericksViewModelConfig<*>) -> Unit) {
         onConfigProvidedListener.remove(callback)
     }
-
-    protected operator fun CoroutineContext.plus(other: CoroutineContext?) = if (other == null) this else this + other
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
@@ -31,7 +31,7 @@ open class MavericksViewModelConfigFactory(
      */
     val contextOverride: CoroutineContext = EmptyCoroutineContext,
     /**
-     * Provide a context that will be used in the [CoroutinesStateStore]
+     * Provide a context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
      */
     val storeContextOverride: CoroutineContext = EmptyCoroutineContext
 ) {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
@@ -30,6 +30,9 @@ open class MavericksViewModelConfigFactory(
      * and [Dispatchers.Main.immediate].
      */
     val contextOverride: CoroutineContext = EmptyCoroutineContext,
+    /**
+     * Provide a context that will be used in the [CoroutinesStateStore]
+     */
     val storeContextOverride: CoroutineContext = EmptyCoroutineContext
 ) {
 


### PR DESCRIPTION
this is an implementation of #389 

Added an extension that converts `ThreadPolicy` to a `CoroutineContext.Element` so then it can be simply injected to any coroutine scope/context. Implementation is similar to `ThreadLocalElement` from coroutines lib

Also added storeContextOverride to ConfigFactory so ThreadPolicy can be injected via `Maverics.initialize`:
```
val policy = StrictMode.ThreadPolicy.Builder()
    .detectNetwork()
    .penaltyDialog()
    .build()
Mavericks.initialize(this, viewModelConfigFactory = MavericksViewModelConfigFactory(
    context = this,
    storeContextOverride = if (isDebuggable()) policy.asContextElement() else EmptyCoroutineContext
))
```

it also means users will be able to provide their own dispatcher for state store, like Dispatchers.Default (we considered using it by default instead of cached executor).

ThreadPolicy has a lot of options, and now users can decide what to detect (network, disk reads, disk writes, slow operations) and how to react on violation (death, log, dialog, screen flash etc). I don't think we need to enforce certain policy. Example of detectNetwork + penaltyDialog: 
![image](https://user-images.githubusercontent.com/7599577/93713988-a1f02400-fb70-11ea-98a6-e92e7134a78e.png)
