### PR TITLE
Never complete ViewModel.stateFlow

### DIFF
--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/MavericksViewModelTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/MavericksViewModelTest.kt
@@ -134,9 +134,10 @@ class MavericksViewModelTest : BaseTest() {
         block: suspend MavericksViewModelTestViewModel.() -> Unit
     ) = runBlockingTest {
         val states = mutableListOf<BaseMavericksViewModelTestState>()
-        viewModel.stateFlow.onEach { states += it }.launchIn(this)
+        val consumerJob = viewModel.stateFlow.onEach { states += it }.launchIn(this)
         viewModel.runInViewModel(block)
         viewModel.onCleared()
+        consumerJob.cancel()
         // We stringify the state list to make all exceptions equal each other. Without it, the stack traces cause tests to fail.
         assertEquals(expectedState.toList().toString(), states.toString())
     }


### PR DESCRIPTION
There are three reasons of this change:
1. It's very likely that CoroutineStateStore will be backed by [SharedFlow](https://github.com/Kotlin/kotlinx.coroutines/issues/2034) once it will be released. SharedFlow never completes, so it's good to make this decision now to avoid behavior change in the future. 
2. @gpeal and me didn't find good usecases for completeable stateFlow. But we found a case when it's better to have a flow that never completes - for example: viewModel.stateFlow.first { // condition } may complete exceptionally if Store's scope cancelled before condition.
3. It also matches behavior from mvrx 1.x - there was no `.onComplete()` call in RealMvRxStateStore. (There was no similar api to `stateFlow` though, but anyway). 

Reminder: CI checks do not run for my PRs, locally I ran `gradlew testDebugUnitTest detekt assembleDebug`