### PR TITLE
Coroutine api tweaks

### DIFF
--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
     // Build tools and SDK
     const val buildTools = "29.0.3"
     const val compileSdk = 29
-    const val gradlePlugin = "4.0.0"
+    const val gradlePlugin = "4.1.0"
     const val kotlin = "1.4.10"
     const val minSdk = 16
     const val targetSdk = 29

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sun Oct 11 14:29:09 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-5-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Oct 11 14:29:09 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-5-all.zip

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericks.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericks.kt
@@ -2,12 +2,14 @@ package com.airbnb.mvrx.mocking
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import androidx.lifecycle.LifecycleOwner
 import com.airbnb.mvrx.CoroutinesStateStore
 import com.airbnb.mvrx.DefaultViewModelDelegateFactory
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksStateStore
+import com.airbnb.mvrx.MavericksView
 import com.airbnb.mvrx.MavericksViewModelConfigFactory
 import com.airbnb.mvrx.ScriptableStateStore
 import com.airbnb.mvrx.mocking.MockableMavericks.initialize
@@ -122,7 +124,7 @@ object MockableMavericks {
          */
         mocksEnabled: Boolean,
         /**
-         * True if debug checks should be enabled
+         * True if debug checks should be enabled.
          */
         debugMode: Boolean,
         /**
@@ -137,7 +139,14 @@ object MockableMavericks {
         /**
          * Provide a coroutine context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
          */
-        stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext
+        stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+        /**
+         * Provide a context that will be added to the coroutine scope when a subscription is registered (eg [MavericksView.onEach]).
+         *
+         * By default subscriptions use [MavericksView.subscriptionLifecycleOwner] and [LifecycleOwner.lifecycleScope] to
+         * retrieve a coroutine scope to launch the subscription in.
+         */
+        subscriptionCoroutineContextOverride: CoroutineContext = EmptyCoroutineContext,
     ) {
         enableMockPrinterBroadcastReceiver = mocksEnabled
         enableMavericksViewMocking = mocksEnabled
@@ -147,7 +156,8 @@ object MockableMavericks {
                 applicationContext = applicationContext?.applicationContext,
                 debugMode = debugMode,
                 viewModelCoroutineContext = viewModelCoroutineContext,
-                stateStoreCoroutineContext = stateStoreCoroutineContext
+                stateStoreCoroutineContext = stateStoreCoroutineContext,
+                subscriptionCoroutineContextOverride = subscriptionCoroutineContextOverride
             )
             Mavericks.initialize(
                 debugMode,
@@ -160,7 +170,8 @@ object MockableMavericks {
                 MavericksViewModelConfigFactory(
                     debugMode,
                     viewModelCoroutineContext,
-                    stateStoreCoroutineContext
+                    stateStoreCoroutineContext,
+                    subscriptionCoroutineContextOverride
                 ),
                 DefaultViewModelDelegateFactory()
             )

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericks.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericks.kt
@@ -2,15 +2,21 @@ package com.airbnb.mvrx.mocking
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import com.airbnb.mvrx.CoroutinesStateStore
+import com.airbnb.mvrx.DefaultViewModelDelegateFactory
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksStateStore
+import com.airbnb.mvrx.MavericksViewModelConfigFactory
 import com.airbnb.mvrx.ScriptableStateStore
 import com.airbnb.mvrx.mocking.MockableMavericks.initialize
 import com.airbnb.mvrx.mocking.printer.MavericksMockPrinter
 import com.airbnb.mvrx.mocking.printer.MockPrinterConfiguration
 import com.airbnb.mvrx.mocking.printer.ViewModelStatePrinter
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Entry point for setting up Mavericks for the app in a mockable way.
@@ -84,12 +90,12 @@ object MockableMavericks {
      *
      * Calling this subsequent times will replace the plugins with new instances.
      */
-    fun initialize(context: Context) {
-        val isDebuggable = context.isDebuggable()
+    fun initialize(applicationContext: Context) {
+        val isDebuggable = applicationContext.isDebuggable()
         initialize(
             mocksEnabled = isDebuggable,
             debugMode = isDebuggable,
-            context = context
+            applicationContext = applicationContext
         )
     }
 
@@ -109,22 +115,55 @@ object MockableMavericks {
      * system is automatically enabled.
      *
      * Calling this subsequent times will replace the plugins with new instances.
-     *
-     * @param debugMode True if debug checks should be enabled
-     * @param mocksEnabled True if ViewModel mocking should be enabled.
-     * @param context Application context. If provided this will be used to register a
-     * [ViewModelStatePrinter] for each ViewModel to support mock state printing.
      */
-    fun initialize(mocksEnabled: Boolean, debugMode: Boolean, context: Context?) {
+    fun initialize(
+        /**
+         * True if ViewModel mocking should be enabled.
+         */
+        mocksEnabled: Boolean,
+        /**
+         * True if debug checks should be enabled
+         */
+        debugMode: Boolean,
+        /**
+         * Application context. If provided this will be used to register a [ViewModelStatePrinter] for each ViewModel to support mock state printing.
+         */
+        applicationContext: Context?,
+        /**
+         * Provide a default coroutine context for viewModelScope in all view models. It will be added after [SupervisorJob]
+         * and [Dispatchers.Main.immediate].
+         */
+        viewModelCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+        /**
+         * Provide a coroutine context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
+         */
+        stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext
+    ) {
         enableMockPrinterBroadcastReceiver = mocksEnabled
         enableMavericksViewMocking = mocksEnabled
 
         if (mocksEnabled) {
-            val mockConfigFactory = MockMavericksViewModelConfigFactory(context?.applicationContext, debugMode)
-            val mockViewModelDelegateFactory = MockViewModelDelegateFactory(mockConfigFactory)
-            Mavericks.initialize(debugMode, mockConfigFactory, mockViewModelDelegateFactory)
+            val configFactory = MockMavericksViewModelConfigFactory(
+                applicationContext = applicationContext?.applicationContext,
+                debugMode = debugMode,
+                viewModelCoroutineContext = viewModelCoroutineContext,
+                stateStoreCoroutineContext = stateStoreCoroutineContext
+            )
+            Mavericks.initialize(
+                debugMode,
+                configFactory,
+                MockViewModelDelegateFactory(configFactory)
+            )
         } else {
-            Mavericks.initialize(debugMode)
+            Mavericks.initialize(
+                debugMode,
+                MavericksViewModelConfigFactory(
+                    debugMode,
+                    viewModelCoroutineContext,
+                    stateStoreCoroutineContext
+                ),
+                DefaultViewModelDelegateFactory()
+            )
         }
     }
 

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericks.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericks.kt
@@ -137,7 +137,8 @@ object MockableMavericks {
          */
         viewModelCoroutineContext: CoroutineContext = EmptyCoroutineContext,
         /**
-         * Provide a coroutine context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
+         * Provide an additional context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
+         * By default these calls are executed with a shared thread pool dispatcher that is private to [CoroutinesStateStore]
          */
         stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext,
         /**

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericksViewModelConfig.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericksViewModelConfig.kt
@@ -160,20 +160,20 @@ open class MockMavericksViewModelConfigFactory(
      * The application context. If provided this will be used to register a
      * [ViewModelStatePrinter] for each ViewModel to enable mock state printing.
      */
-    context: Context?,
+    applicationContext: Context?,
     debugMode: Boolean = true,
     /**
-     * Provide a default context for viewModelScope. It will be added after [SupervisorJob]
+     * Provide a default coroutine context for viewModelScope in all view models. It will be added after [SupervisorJob]
      * and [Dispatchers.Main.immediate].
      */
-    contextOverride: CoroutineContext = EmptyCoroutineContext,
+    viewModelCoroutineContext: CoroutineContext = EmptyCoroutineContext,
     /**
-     * Provide a context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
+     * Provide a coroutine context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
      */
-    storeContextOverride: CoroutineContext = EmptyCoroutineContext
-) : MavericksViewModelConfigFactory(debugMode, contextOverride, storeContextOverride) {
+    stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext
+) : MavericksViewModelConfigFactory(debugMode, viewModelCoroutineContext, stateStoreCoroutineContext) {
 
-    private val applicationContext: Context? = context?.applicationContext
+    private val applicationContext: Context? = applicationContext?.applicationContext
 
     private val mockConfigs = mutableMapOf<MavericksStateStore<*>, MockableMavericksViewModelConfig<*>>()
 
@@ -248,8 +248,9 @@ open class MockMavericksViewModelConfigFactory(
             // we use it as an opportunity to register the mock printer on all view models.
             // This lets us capture singleton viewmodels as well.
             val viewModelStatePrinter = ViewModelStatePrinter(viewModel)
+            val enableMockPrinterBroadcastReceiver = MockableMavericks.enableMockPrinterBroadcastReceiver
             applicationContext?.let { context ->
-                if (MockableMavericks.enableMockPrinterBroadcastReceiver) {
+                if (enableMockPrinterBroadcastReceiver) {
                     viewModelStatePrinter.register(context)
                 }
             }
@@ -259,7 +260,7 @@ open class MockMavericksViewModelConfigFactory(
             mockConfigs[stateStore] = config
             stateStore.addOnCancelListener { stateStore ->
                 applicationContext?.let { context ->
-                    if (MockableMavericks.enableMockPrinterBroadcastReceiver) {
+                    if (enableMockPrinterBroadcastReceiver) {
                         viewModelStatePrinter.unregister(context)
                     }
                 }

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericksViewModelConfig.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockableMavericksViewModelConfig.kt
@@ -1,12 +1,14 @@
 package com.airbnb.mvrx.mocking
 
 import android.content.Context
+import androidx.lifecycle.LifecycleOwner
 import com.airbnb.mvrx.CoroutinesStateStore
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelConfig
 import com.airbnb.mvrx.MavericksViewModelConfigFactory
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksStateStore
+import com.airbnb.mvrx.MavericksView
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.ScriptableStateStore
 import com.airbnb.mvrx.mocking.printer.ViewModelStatePrinter
@@ -170,8 +172,15 @@ open class MockMavericksViewModelConfigFactory(
     /**
      * Provide a coroutine context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
      */
-    stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext
-) : MavericksViewModelConfigFactory(debugMode, viewModelCoroutineContext, stateStoreCoroutineContext) {
+    stateStoreCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+    /**
+     * Provide a context that will be added to the coroutine scope when a subscription is registered (eg [MavericksView.onEach]).
+     *
+     * By default subscriptions use [MavericksView.subscriptionLifecycleOwner] and [LifecycleOwner.lifecycleScope] to
+     * retrieve a coroutine scope to launch the subscription in.
+     */
+    subscriptionCoroutineContextOverride: CoroutineContext = EmptyCoroutineContext,
+) : MavericksViewModelConfigFactory(debugMode, viewModelCoroutineContext, stateStoreCoroutineContext, subscriptionCoroutineContextOverride) {
 
     private val applicationContext: Context? = applicationContext?.applicationContext
 

--- a/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/BaseTest.kt
+++ b/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/BaseTest.kt
@@ -23,7 +23,7 @@ abstract class BaseTest {
     @After
     fun resetConfigurationDefaults() {
         // Use a null context since we don't need mock printing during tests
-        MockableMavericks.initialize(debugMode = true, mocksEnabled = true, context = null)
+        MockableMavericks.initialize(debugMode = true, mocksEnabled = true, applicationContext = null)
         MockableMavericks.mockConfigFactory.mockBehavior = MockBehavior(
             stateStoreBehavior = MockBehavior.StateStoreBehavior.Synchronous
         )

--- a/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/MavericksViewModelConfigTest.kt
+++ b/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/MavericksViewModelConfigTest.kt
@@ -15,7 +15,7 @@ class MavericksViewModelConfigTest : BaseTest() {
 
     @Test
     fun mockBehaviorIsConfigurableInBlock() {
-        val provider = MockMavericksViewModelConfigFactory(context = null)
+        val provider = MockMavericksViewModelConfigFactory(applicationContext = null)
 
         val originalBehavior = provider.mockBehavior
         val newBehavior =

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -246,9 +246,8 @@ abstract class MavericksViewModel<S : MavericksState>(
         setState { reducer(Loading()) }
 
         return catch { error -> setState { reducer(Fail(error)) } }
-            .onEach {
-                setState { reducer(Success(it)) }
-            }.launchIn(viewModelScope + (dispatcher ?: EmptyCoroutineContext))
+            .onEach { value -> setState { reducer(Success(value)) } }
+            .launchIn(viewModelScope + (dispatcher ?: EmptyCoroutineContext))
     }
 
     /**
@@ -417,7 +416,7 @@ abstract class MavericksViewModel<S : MavericksState>(
             flowWhenStarted(lifecycleOwner)
         }
 
-        val scope = lifecycleOwner?.lifecycleScope?.let { it + configFactory.subscriptionCoroutineContextOverride } ?: viewModelScope
+        val scope = (lifecycleOwner?.lifecycleScope ?: viewModelScope) + configFactory.subscriptionCoroutineContextOverride
         return scope.launch(start = CoroutineStart.UNDISPATCHED) {
             // Use yield to ensure flow collect coroutine is dispatched rather than invoked immediately.
             // This is necessary when Dispatchers.Main.immediate is used in scope.

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -42,9 +42,12 @@ abstract class MavericksViewModel<S : MavericksState>(
     initialState: S
 ) {
 
+    // Use the same factory for the life of the viewmodel, as it might change after this viewmodel is created (especially during tests)
+    private val configFactory = Mavericks.viewModelConfigFactory
+
     @Suppress("LeakingThis")
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    val config: MavericksViewModelConfig<S> = Mavericks.viewModelConfigFactory.provideConfig(
+    val config: MavericksViewModelConfig<S> = configFactory.provideConfig(
         this,
         initialState
     )
@@ -414,7 +417,7 @@ abstract class MavericksViewModel<S : MavericksState>(
             flowWhenStarted(lifecycleOwner)
         }
 
-        val scope = lifecycleOwner?.lifecycleScope?.let { it + Mavericks.viewModelConfigFactory.contextOverride } ?: viewModelScope
+        val scope = lifecycleOwner?.lifecycleScope?.let { it + configFactory.subscriptionCoroutineContextOverride } ?: viewModelScope
         return scope.launch(start = CoroutineStart.UNDISPATCHED) {
             // Use yield to ensure flow collect coroutine is dispatched rather than invoked immediately.
             // This is necessary when Dispatchers.Main.immediate is used in scope.

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
@@ -31,7 +31,8 @@ open class MavericksViewModelConfigFactory(
      */
     val contextOverride: CoroutineContext = EmptyCoroutineContext,
     /**
-     * Provide a context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
+     * Provide an additional context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
+     * By default these calls are executed with a shared thread pool dispatcher that is private to [CoroutinesStateStore]
      */
     val storeContextOverride: CoroutineContext = EmptyCoroutineContext,
     /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfigFactory.kt
@@ -2,6 +2,7 @@ package com.airbnb.mvrx
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -32,7 +33,14 @@ open class MavericksViewModelConfigFactory(
     /**
      * Provide a context that will be used in the [CoroutinesStateStore]. All withState/setState calls will be executed in this context.
      */
-    val storeContextOverride: CoroutineContext = EmptyCoroutineContext
+    val storeContextOverride: CoroutineContext = EmptyCoroutineContext,
+    /**
+     * Provide a context that will be added to the coroutine scope when a subscription is registered (eg [MavericksView.onEach]).
+     *
+     * By default subscriptions use [MavericksView.subscriptionLifecycleOwner] and [LifecycleOwner.lifecycleScope] to
+     * retrieve a coroutine scope to launch the subscription in.
+     */
+    val subscriptionCoroutineContextOverride: CoroutineContext = EmptyCoroutineContext,
 ) {
 
     /**

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/BaseTest.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.After
 import org.junit.AfterClass
@@ -40,7 +41,7 @@ abstract class BaseTest {
 
     @Before
     fun setupViewModelConfigFactory() {
-        Mavericks.viewModelConfigFactory = MavericksViewModelConfigFactory(true, contextOverride = TestCoroutineDispatcher())
+        Mavericks.viewModelConfigFactory = MavericksViewModelConfigFactory(true, contextOverride = Dispatchers.Unconfined)
     }
 
     @After

--- a/testing/src/main/kotlin/com/airbnb/mvrx/test/MvRxTestRule.kt
+++ b/testing/src/main/kotlin/com/airbnb/mvrx/test/MvRxTestRule.kt
@@ -61,7 +61,7 @@ class MvRxTestRule(
     private fun setupMocking() {
         val mocksEnabled = viewModelMockBehavior != null
         // Use a null context since we don't need mock printing during tests
-        MockableMavericks.initialize(debugMode = debugMode, mocksEnabled = mocksEnabled, context = null)
+        MockableMavericks.initialize(debugMode = debugMode, mocksEnabled = mocksEnabled, applicationContext = null)
 
         if (viewModelMockBehavior != null) {
             MockableMavericks.mockConfigFactory.mockBehavior = viewModelMockBehavior


### PR DESCRIPTION
Makes a few changes to how coroutines are executed in view models, as well as the public API for controlling coroutines:

- MockableMavericks initialization now accepts the context override parameters for easy configuration. We may want to add this to `Mavericks.initialize` as well
- coroutine `execute` functions in MavericksViewModel now have a null dispatcher default instead of Dispatchers.main.immediate. When null, the plain view model scope is used
- for viewmodel subscription functions, when the subscriber's lifecycle is passed and the lifecycle coroutine scope is used to launch the coroutine, the global coroutine context override is first added to that scope
- Flow.execute had a `catch` statement added, which catches exceptions and reduces them with `Fail`, to make it consistent with other execute functions

Overall, this makes it so that the coroutine context override applied in Mavericks initialization is used in all viewmodel coroutine uses so we can have a consistent, flexible global default. Individual executions can still specify a custom dispatchers.