### PR TITLE
Mark all @RestrictTo APIs with @InternalMavericksApi

### DIFF
--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -1,10 +1,19 @@
 import com.airbnb.mvrx.JacocoReportTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: "jacoco"
 apply plugin: "com.vanniktech.maven.publish"
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xopt-in=com.airbnb.mvrx.InternalMavericksApi',
+        ]
+    }
+}
 
 android {
     resourcePrefix 'mavericks_'

--- a/mvrx-mocking/build.gradle
+++ b/mvrx-mocking/build.gradle
@@ -1,4 +1,5 @@
 import com.airbnb.mvrx.JacocoReportTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
@@ -6,6 +7,14 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "jacoco"
 apply plugin: "com.vanniktech.maven.publish"
 apply plugin: 'kotlin-android-extensions'
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xopt-in=com.airbnb.mvrx.InternalMavericksApi',
+        ]
+    }
+}
 
 android {
     resourcePrefix 'mvrx_'

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockBuilder.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockBuilder.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.airbnb.mvrx.Async
+import com.airbnb.mvrx.InternalMavericksApi
 import com.airbnb.mvrx.MavericksView
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksState
@@ -1427,6 +1428,7 @@ open class MavericksViewMocks<V : MockableMavericksView, Args : Parcelable> @Pub
          * can only be created via [getFrom].
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @InternalMavericksApi
         fun <R> allowCreationForTesting(block: () -> R): R {
             allowCreationForTesting = true
             val result: R = block()

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/SynchronousMavericksStateStore.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/SynchronousMavericksStateStore.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx.mocking
 
 import androidx.annotation.RestrictTo
+import com.airbnb.mvrx.InternalMavericksApi
 import com.airbnb.mvrx.MavericksStateStore
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
  * synchronously.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 class SynchronousMavericksStateStore<S : Any>(initialState: S) : MavericksStateStore<S> {
 
     private val stateSharedFlow = MutableSharedFlow<S>(

--- a/mvrx-rxjava2/build.gradle
+++ b/mvrx-rxjava2/build.gradle
@@ -1,10 +1,19 @@
 import com.airbnb.mvrx.JacocoReportTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 apply plugin: "jacoco"
 apply plugin: "com.vanniktech.maven.publish"
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xopt-in=com.airbnb.mvrx.InternalMavericksApi',
+        ]
+    }
+}
 
 android {
     resourcePrefix "mvrx_"

--- a/mvrx/build.gradle
+++ b/mvrx/build.gradle
@@ -1,10 +1,20 @@
 import com.airbnb.mvrx.JacocoReportTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 apply plugin: "jacoco"
 apply plugin: "com.vanniktech.maven.publish"
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xopt-in=kotlin.RequiresOptIn',
+                '-Xopt-in=com.airbnb.mvrx.InternalMavericksApi',
+        ]
+    }
+}
 
 android {
     resourcePrefix "mvrx_"

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -59,6 +59,7 @@ data class Success<out T>(private val value: T) : Async<T>(complete = true, shou
      * @see Async.getMetadata
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @InternalMavericksApi
     var metadata: Any? = null
 }
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/InternalMavericksApi.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/InternalMavericksApi.kt
@@ -1,0 +1,7 @@
+package com.airbnb.mvrx
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is an internal Mavericks API. It is not intended for external use."
+)
+annotation class InternalMavericksApi

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
@@ -17,6 +17,7 @@ import kotlin.reflect.KProperty
  */
 @Suppress("FunctionName")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <T : Fragment> T._fragmentArgsProvider(): Any? = arguments?.get(Mavericks.KEY_ARG)
 
 /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksFactory.kt
@@ -84,6 +84,7 @@ private fun <VM : MavericksViewModel<S>, S : MavericksState> createDefaultViewMo
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 open class ViewModelDoesNotExistException(message: String) : IllegalStateException(message) {
     constructor(
         viewModelClass: Class<*>,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateFactory.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import java.lang.reflect.Modifier
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
+@InternalMavericksApi
 interface MavericksStateFactory<VM : MavericksViewModel<S>, S : MavericksState> {
 
     fun createInitialState(
@@ -16,6 +17,7 @@ interface MavericksStateFactory<VM : MavericksViewModel<S>, S : MavericksState> 
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 class RealMavericksStateFactory<VM : MavericksViewModel<S>, S : MavericksState> : MavericksStateFactory<VM, S> {
 
     override fun createInitialState(

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateStore.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import kotlinx.coroutines.flow.Flow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 interface MavericksStateStore<S : Any> {
     val state: S
     val flow: Flow<S>

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksTestOverrides.java
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksTestOverrides.java
@@ -4,6 +4,7 @@ package com.airbnb.mvrx;
 import androidx.annotation.RestrictTo;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 public class MavericksTestOverrides {
     /**
      * This should only be set by the MvRxTestRule from the mvrx-testing artifact.

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksView.kt
@@ -12,12 +12,12 @@ import kotlin.reflect.KProperty1
 
 // Set of [MavericksView identity hash codes that have a pending invalidate.
 private val pendingInvalidates = HashSet<Int>()
-private val handler = Handler(Looper.getMainLooper(), Handler.Callback { message ->
+private val handler = Handler(Looper.getMainLooper()) { message ->
     val view = message.obj as MavericksView
     pendingInvalidates.remove(System.identityHashCode(view))
     if (view.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) view.invalidate()
     true
-})
+}
 
 /**
  * If any callbacks to run [MavericksView.invalidate] have been posted with [MavericksView.postInvalidate]

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -47,6 +47,7 @@ abstract class MavericksViewModel<S : MavericksState>(
 
     @Suppress("LeakingThis")
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @InternalMavericksApi
     val config: MavericksViewModelConfig<S> = configFactory.provideConfig(
         this,
         initialState

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfig.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfig.kt
@@ -15,6 +15,7 @@ abstract class MavericksViewModelConfig<S : Any>(
     /**
      * The state store instance that will control the state of the ViewModel.
      */
+    @InternalMavericksApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val stateStore: MavericksStateStore<S>,
     /**
      * The coroutine scope that will be provided to the view model.

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelExtensions.kt
@@ -13,6 +13,7 @@ import kotlin.reflect.KProperty1
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState> VM._internal(
     owner: LifecycleOwner?,
     deliveryMode: DeliveryMode = RedeliverOnStart,
@@ -24,6 +25,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState> VM._internal(
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A> VM._internal1(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -41,6 +43,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A> VM._internal1(
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B> VM._internal2(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -59,6 +62,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B> VM._internal2(
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C> VM._internal3(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -78,6 +82,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C> VM._internal3(
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D> VM._internal4(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -98,6 +103,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D> VM._internal4(
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E> VM._internal5(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -119,6 +125,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E> VM._internal
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F> VM._internal6(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -141,6 +148,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F> VM._inter
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F, G> VM._internal7(
     owner: LifecycleOwner?,
     prop1: KProperty1<S, A>,
@@ -164,6 +172,7 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F, G> VM._in
  * https://issuetracker.google.com/issues/168357308
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, T> VM._internalSF(
     owner: LifecycleOwner?,
     asyncProp: KProperty1<S, Async<T>>,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -13,6 +13,7 @@ import java.io.Serializable
  * of two separate ones. The logic for providing the correct scope is inside the method.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
+@InternalMavericksApi
 object MavericksViewModelProvider {
     /**
      * MvRx specific ViewModelProvider used for creating a BaseMavericksViewModel scoped to either a [Fragment] or [FragmentActivity].

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewModelDelegateProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/ViewModelDelegateProvider.kt
@@ -50,6 +50,7 @@ abstract class MavericksDelegateProvider<T, R> {
  * should be instantiated.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 interface ViewModelDelegateFactory {
     /**
      * Create a Lazy ViewModel for the given Fragment.

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
@@ -13,6 +13,7 @@ private object UninitializedValue
  * This was copied from SynchronizedLazyImpl but modified to automatically initialize in ON_CREATE.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalMavericksApi
 @SuppressWarnings("Detekt.ClassNaming")
 class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: () -> T) : Lazy<T>,
     Serializable {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,8 +1,19 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 apply plugin: "com.vanniktech.maven.publish"
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xopt-in=com.airbnb.mvrx.InternalMavericksApi',
+        ]
+    }
+}
+
 
 android {
     resourcePrefix "mvrx_"

--- a/testing/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesProxy.java
+++ b/testing/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesProxy.java
@@ -9,6 +9,7 @@ import com.airbnb.mvrx.test.MvRxTestRule;
  * this is Java because the flag is package private.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
+@InternalMavericksApi
 public class MvRxTestOverridesProxy {
 
     public static void forceDisableLifecycleAwareObserver(Boolean disableLifecycleAwareObserver) {


### PR DESCRIPTION
`@RestrictTo` doesn't really work so this approach will be much more aggressive about failing builds where internal APIs are used.
Fixes #474 

@denis-bezrukov