### PR TITLE
Add MavericksViewModel.awaitState

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
@@ -156,6 +157,16 @@ abstract class MavericksViewModel<S : MavericksState>(
         } else {
             stateStore.set(reducer)
         }
+    }
+
+    /**
+     * Calling this function suspends until all pending setState reducers are run and then returns the latest state.
+     * As a result, it is safe to call setState { } and assume that the result from a subsequent awaitState() call will have that state.
+     */
+    suspend fun awaitState(): S {
+        val deferredState = CompletableDeferred<S>()
+        withState(deferredState::complete)
+        return deferredState.await()
     }
 
     /**

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/MavericksViewModelTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/MavericksViewModelTest.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
@@ -21,6 +20,8 @@ class MavericksViewModelTestViewModel : MavericksViewModel<BaseMavericksViewMode
     suspend fun runInViewModel(block: suspend MavericksViewModelTestViewModel.() -> Unit) {
         block()
     }
+
+    fun setInt(int: Int) = setState { copy(int = int) }
 }
 
 @ExperimentalCoroutinesApi
@@ -128,6 +129,16 @@ class MavericksViewModelTest : BaseTest() {
         BaseMavericksViewModelTestState(int = 2)
     ) {
         flowOf(1, 2).setOnEach { copy(int = it) }
+    }
+
+    @Test
+    fun testAwaitState() = runInViewModelBlocking(
+        BaseMavericksViewModelTestState(int = 0),
+        BaseMavericksViewModelTestState(int = 1),
+        ) {
+        setInt(1)
+        val state = awaitState()
+        assertEquals(1, state.int)
     }
 
     private fun runInViewModelBlocking(


### PR DESCRIPTION
Fixes https://github.com/airbnb/MvRx/issues/484

One thing I noticed is that execute and setOnEach is a public API and I think it should be protected. I can change the visibility in a subsequent PR unless you can think of a valid use case.

@denis-bezrukov 