### PR TITLE
Make MavericksViewModel extension functions protected

### DIFF
--- a/launcher/src/main/java/com/airbnb/mvrx/launcher/MavericksLauncherMockActivity.kt
+++ b/launcher/src/main/java/com/airbnb/mvrx/launcher/MavericksLauncherMockActivity.kt
@@ -159,9 +159,9 @@ class MavericksLauncherMockActivity : MavericksBaseLauncherActivity() {
                     val finishAfterMs: Long = if (isInitializing) 3000 else 500
 
                     Handler().postDelayed({
-                                              onMockLoaded(activity, mock, mockedView)
-                                              activity.finish()
-                                          }, finishAfterMs)
+                      onMockLoaded(activity, mock, mockedView)
+                      activity.finish()
+                  }, finishAfterMs)
                 }
             } catch (e: Throwable) {
                 Log.e(

--- a/launcher/src/main/java/com/airbnb/mvrx/launcher/MavericksLauncherMockActivity.kt
+++ b/launcher/src/main/java/com/airbnb/mvrx/launcher/MavericksLauncherMockActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Parcelable
 import android.util.Log
+import androidx.core.os.postDelayed
 import androidx.fragment.app.Fragment
 import com.airbnb.mvrx.MavericksView
 import com.airbnb.mvrx.MavericksViewModelConfig
@@ -158,10 +159,10 @@ class MavericksLauncherMockActivity : MavericksBaseLauncherActivity() {
                         mock.mock.isDefaultInitialization || mock.mock.isForProcessRecreation
                     val finishAfterMs: Long = if (isInitializing) 3000 else 500
 
-                    Handler().postDelayed({
-                      onMockLoaded(activity, mock, mockedView)
-                      activity.finish()
-                  }, finishAfterMs)
+                    Handler().postDelayed(finishAfterMs) {
+                        onMockLoaded(activity, mock, mockedView)
+                        activity.finish()
+                    }
                 }
             } catch (e: Throwable) {
                 Log.e(

--- a/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/MavericksViewModelConfigTest.kt
+++ b/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/MavericksViewModelConfigTest.kt
@@ -63,7 +63,7 @@ class MavericksViewModelConfigTest : BaseTest() {
             providedConfig = config
         }
 
-        Mavericks.viewModelConfigFactory!!.addOnConfigProvidedListener(onConfigProvided)
+        Mavericks.viewModelConfigFactory.addOnConfigProvidedListener(onConfigProvided)
         val vm = TestViewModel()
 
         assertEquals(vm, providedVm)
@@ -80,8 +80,8 @@ class MavericksViewModelConfigTest : BaseTest() {
             providedConfig = config
         }
 
-        Mavericks.viewModelConfigFactory!!.addOnConfigProvidedListener(onConfigProvided)
-        Mavericks.viewModelConfigFactory!!.removeOnConfigProvidedListener(onConfigProvided)
+        Mavericks.viewModelConfigFactory.addOnConfigProvidedListener(onConfigProvided)
+        Mavericks.viewModelConfigFactory.removeOnConfigProvidedListener(onConfigProvided)
         TestViewModel()
 
         assertNull(providedConfig)

--- a/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/MockBuilderTest.kt
+++ b/mvrx-mocking/src/test/kotlin/com/airbnb/mvrx/mocking/MockBuilderTest.kt
@@ -25,6 +25,7 @@ import kotlin.reflect.KClass
 
 class MockBuilderTest : BaseTest() {
 
+    @Suppress("DEPRECATION")
     @Rule
     @JvmField
     val expectedException: ExpectedException = ExpectedException.none()
@@ -44,7 +45,7 @@ class MockBuilderTest : BaseTest() {
         fragment = TestFragment()
     }
 
-    fun <Args : Parcelable> mockNoViewModels(
+    private fun <Args : Parcelable> mockNoViewModels(
         defaultArgs: Args?,
         block: MockBuilder<TestFragment, Args>.() -> Unit
     ): MockBuilder<TestFragment, Args> = fragment.run {
@@ -53,7 +54,7 @@ class MockBuilderTest : BaseTest() {
         }
     }
 
-    fun <Args : Parcelable> mockSingleViewModel(
+    private fun <Args : Parcelable> mockSingleViewModel(
         defaultArgs: Args?,
         block: SingleViewModelMockBuilder<TestFragment, Args, State>.() -> Unit
     ): MockBuilder<TestFragment, Args> = fragment.run {
@@ -62,7 +63,7 @@ class MockBuilderTest : BaseTest() {
         }
     }
 
-    fun <Args : Parcelable> mockTwoViewModels(
+    private fun <Args : Parcelable> mockTwoViewModels(
         defaultArgs: Args? = null,
         block: TwoViewModelMockBuilder<TestFragment, TestViewModel, State, TestViewModel, State, Args>.() -> Unit
     ): MockBuilder<TestFragment, Args> = fragment.run {
@@ -78,7 +79,7 @@ class MockBuilderTest : BaseTest() {
         }
     }
 
-    fun <Args : Parcelable> mockThreeViewModels(
+    private fun <Args : Parcelable> mockThreeViewModels(
         defaultArgs: Args? = null,
         block: ThreeViewModelMockBuilder<TestFragment, TestViewModel, State, TestViewModel, State, TestViewModel, State, Args>.() -> Unit
     ): MockBuilder<TestFragment, Args> = fragment.run {
@@ -373,7 +374,7 @@ class MockBuilderTest : BaseTest() {
         // Trying to set a value on the async property when it is uninitialized should give a clear error message
         val state = baseState.copy(asyncBookingDetails = Uninitialized)
 
-        val mocks = mockSingleViewModel(null) {
+        mockSingleViewModel(null) {
             state("my state") {
                 state.set { ::asyncBookingDetails { success { ::disclaimerInfo { ::text } } } }
                     .with { "hello" }
@@ -390,7 +391,7 @@ class MockBuilderTest : BaseTest() {
         // Trying to set a value on a null property should give a clear warning
         val state = baseState.copy(bookingDetails = BookingDetails(disclaimerInfo = null))
 
-        val mocks = mockSingleViewModel(null) {
+        mockSingleViewModel(null) {
             state("my state") {
                 state.set { ::bookingDetails { ::disclaimerInfo { ::text } } }.with { "hello" }
             }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -188,7 +188,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and it likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    fun <T : Any?> Deferred<T>.execute(
+    protected fun <T : Any?> Deferred<T>.execute(
         dispatcher: CoroutineDispatcher? = null,
         retainValue: KProperty1<S, Async<T>>? = null,
         reducer: S.(Async<T>) -> S
@@ -205,7 +205,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and it likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    fun <T : Any?> (suspend () -> T).execute(
+    protected fun <T : Any?> (suspend () -> T).execute(
         dispatcher: CoroutineDispatcher? = null,
         retainValue: KProperty1<S, Async<T>>? = null,
         reducer: S.(Async<T>) -> S
@@ -242,7 +242,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and it likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    fun <T> Flow<T>.execute(
+    protected fun <T> Flow<T>.execute(
         dispatcher: CoroutineDispatcher? = null,
         reducer: S.(Async<T>) -> S
     ): Job {
@@ -270,7 +270,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and it likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    fun <T> Flow<T>.setOnEach(
+    protected fun <T> Flow<T>.setOnEach(
         dispatcher: CoroutineDispatcher? = null,
         reducer: S.(T) -> S
     ): Job {


### PR DESCRIPTION
These functions should only be called from within a ViewModel. The fact that they were not protected in 1.0 seems like an oversight but will remain that way for backwards compatiblity